### PR TITLE
feature: added threejs

### DIFF
--- a/src/cmd/stack/app/package.json
+++ b/src/cmd/stack/app/package.json
@@ -13,6 +13,7 @@
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
     "@tsconfig/svelte": "^2.0.0",
+    "@types/three": "^0.144.0",
     "carbon-components-svelte": "^0.70.12",
     "carbon-icons-svelte": "^11.4.0",
     "rollup": "^2.3.4",
@@ -27,6 +28,9 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "sirv-cli": "^2.0.0"
+    "@threlte/core": "^4.3.2",
+    "@threlte/extras": "^4.4.1",
+    "sirv-cli": "^2.0.0",
+    "three": "^0.146.0"
   }
 }

--- a/src/cmd/stack/app/src/App.svelte
+++ b/src/cmd/stack/app/src/App.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import { onMount } from "svelte";
+	import { createScene } from "./scene";
+
+  let el;
+
+  onMount(() => {
+    createScene(el)
+  });
+
 </script>
 
-<main>
+<main >
   <header>
     <div class="lefty logo-wrap">Sphinx Stack</div>
   </header>
-  <div class="body">body</div>
+	<canvas bind:this={el}></canvas>
 </main>
 
 <style>
@@ -28,8 +36,16 @@
     align-items: center;
   }
   .body {
-    display: flex;
-    height: 100%;
+  /* tell our scene container to take up the full page */
+  position: absolute;
+  width: 100%;
+  height: 100%;
+
+  /*
+    Set the container's background color to the same as the scene's
+    background to prevent flashing on load
+  */
+  background-color: skyblue;
   }
   .lefty {
     width: 15rem;


### PR DESCRIPTION
the start of our threejs stuff

Got threejs running on svelte
<img width="1792" alt="Screen Shot 2022-11-02 at 4 20 14 PM" src="https://user-images.githubusercontent.com/15950706/199604717-e7b794c6-db7d-4e2e-89b2-c8985bc708e2.png">
