### PR TITLE
Changed api port to vite's default 5173 port

### DIFF
--- a/src/modes/stack/app/src/api/cmd.ts
+++ b/src/modes/stack/app/src/api/cmd.ts
@@ -1,4 +1,4 @@
-const IS_DEV = window.location.host === "localhost:8080";
+const IS_DEV = window.location.host === "localhost:5173" || "127.0.0.1:5173";
 
 let root = "/api";
 if (IS_DEV) {


### PR DESCRIPTION
I changed the default window port to suit vite's default API port
@Evanfeenstra 