### PR TITLE
added new env var for boltwall to store db in right location

### DIFF
--- a/src/images/boltwall.rs
+++ b/src/images/boltwall.rs
@@ -153,6 +153,7 @@ fn boltwall(
             jarvis.port
         ),
         format!("SESSION_SECRET={}", node.session_secret),
+        format!("NODE_ENV=docker_development"),
     ];
     let mut extra_vols = None;
 


### PR DESCRIPTION
Right now when we restart boltwall the db gets deleted as it is not part of a volume so we are adding this env var to use the docker development path for our boltwall db