### PR TITLE
Crud/super admin for services

### DIFF
--- a/app/src/api/cmd.ts
+++ b/app/src/api/cmd.ts
@@ -77,7 +77,8 @@ export type Cmd =
   | "UpdateUser"
   | "GetApiToken"
   | "AddNewSwarm"
-  | "UpdateSwarm";
+  | "UpdateSwarm"
+  | "DeleteSwarm";
 
 interface CmdData {
   cmd: Cmd;

--- a/app/src/api/cmd.ts
+++ b/app/src/api/cmd.ts
@@ -76,7 +76,8 @@ export type Cmd =
   | "GetDockerImageTags"
   | "UpdateUser"
   | "GetApiToken"
-  | "AddNewSwarm";
+  | "AddNewSwarm"
+  | "UpdateSwarm";
 
 interface CmdData {
   cmd: Cmd;

--- a/app/src/api/cmd.ts
+++ b/app/src/api/cmd.ts
@@ -75,7 +75,8 @@ export type Cmd =
   | "GetImageDigest"
   | "GetDockerImageTags"
   | "UpdateUser"
-  | "GetApiToken";
+  | "GetApiToken"
+  | "AddNewSwarm";
 
 interface CmdData {
   cmd: Cmd;

--- a/app/src/api/swarm.ts
+++ b/app/src/api/swarm.ts
@@ -134,6 +134,10 @@ export async function update_swarm_details(swarm_info: {
   return await swarmCmd("UpdateSwarm", { ...swarm_info });
 }
 
+export async function delete_swarm(data: { host: string }) {
+  return await swarmCmd("DeleteSwarm", { ...data });
+}
+
 export async function login(username, password) {
   const r = await fetch(`${root}/login`, {
     method: "POST",

--- a/app/src/api/swarm.ts
+++ b/app/src/api/swarm.ts
@@ -125,6 +125,15 @@ export async function add_new_swarm(new_swarm: {
   return await swarmCmd("AddNewSwarm", { ...new_swarm });
 }
 
+export async function update_swarm_details(swarm_info: {
+  id: string;
+  host: string;
+  description: string;
+  instance: string;
+}) {
+  return await swarmCmd("UpdateSwarm", { ...swarm_info });
+}
+
 export async function login(username, password) {
   const r = await fetch(`${root}/login`, {
     method: "POST",

--- a/app/src/api/swarm.ts
+++ b/app/src/api/swarm.ts
@@ -117,6 +117,14 @@ export async function get_api_token() {
   return await swarmCmd("GetApiToken");
 }
 
+export async function add_new_swarm(new_swarm: {
+  host: string;
+  instance: string;
+  description: string;
+}) {
+  return await swarmCmd("AddNewSwarm", { ...new_swarm });
+}
+
 export async function login(username, password) {
   const r = await fetch(`${root}/login`, {
     method: "POST",

--- a/src/bin/super/mod.rs
+++ b/src/bin/super/mod.rs
@@ -150,30 +150,24 @@ pub async fn super_handle(proj: &str, cmd: Cmd, _tag: &str) -> Result<String> {
             SwarmCmd::AddNewSwarm(swarm) => {
                 let mut hm = HashMap::new();
                 match state.find_swarm_by_host(&swarm.host) {
-                    Ok(_swarm) => {
+                    Some(_swarm) => {
                         hm.insert("success", "false");
                         hm.insert("message", "swarm already exist");
                     }
-                    Err(value) => {
-                        if !value {
-                            let new_swarm = RemoteStack {
-                                host: swarm.host,
-                                note: Some(swarm.description),
-                                ec2: Some(swarm.instance),
-                                user: None,
-                                pass: None,
-                            };
-                            state.add_remote_stack(new_swarm);
-                            must_save_stack = true;
-                            hm.insert("success", "true");
-                            hm.insert("message", "Swarm added successfully");
-                        } else {
-                            hm.insert("success", "false");
-                            hm.insert("message", "internal server error");
-                        }
+                    None => {
+                        let new_swarm = RemoteStack {
+                            host: swarm.host,
+                            note: Some(swarm.description),
+                            ec2: Some(swarm.instance),
+                            user: None,
+                            pass: None,
+                        };
+                        state.add_remote_stack(new_swarm);
+                        must_save_stack = true;
+                        hm.insert("success", "true");
+                        hm.insert("message", "Swarm added successfully");
                     }
                 }
-
                 Some(serde_json::to_string(&hm)?)
             }
             SwarmCmd::UpdateSwarm(swarm) => {

--- a/src/bin/super/mod.rs
+++ b/src/bin/super/mod.rs
@@ -203,6 +203,7 @@ pub async fn super_handle(proj: &str, cmd: Cmd, _tag: &str) -> Result<String> {
                 let mut hm = HashMap::new();
                 match state.delete_swarm_by_host(&swarm.host) {
                     Ok(()) => {
+                        must_save_stack = true;
                         hm.insert("success", "true".to_string());
                         hm.insert("message", "Swarm deleted successfully".to_string());
                     }

--- a/src/bin/super/mod.rs
+++ b/src/bin/super/mod.rs
@@ -94,6 +94,11 @@ pub struct UpdateSwarmInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DeleteSwarmInfo {
+    pub host: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "cmd", content = "content")]
 pub enum SwarmCmd {
     GetConfig,
@@ -101,6 +106,7 @@ pub enum SwarmCmd {
     ChangePassword(ChangePasswordInfo),
     AddNewSwarm(AddNewSwarmInfo),
     UpdateSwarm(UpdateSwarmInfo),
+    DeleteSwarm(DeleteSwarmInfo),
 }
 
 // tag is the service name
@@ -191,6 +197,20 @@ pub async fn super_handle(proj: &str, cmd: Cmd, _tag: &str) -> Result<String> {
                     }
                 }
 
+                Some(serde_json::to_string(&hm)?)
+            }
+            SwarmCmd::DeleteSwarm(swarm) => {
+                let mut hm = HashMap::new();
+                match state.delete_swarm_by_host(&swarm.host) {
+                    Ok(()) => {
+                        hm.insert("success", "true".to_string());
+                        hm.insert("message", "Swarm deleted successfully".to_string());
+                    }
+                    Err(msg) => {
+                        hm.insert("message", msg.clone());
+                        hm.insert("success", "false".to_string());
+                    }
+                }
                 Some(serde_json::to_string(&hm)?)
             }
         },

--- a/src/bin/super/state.rs
+++ b/src/bin/super/state.rs
@@ -95,15 +95,15 @@ impl Super {
         self.stacks.push(new_stack);
     }
 
-    pub fn find_swarm_by_host(&self, host: &str) -> Result<&RemoteStack, bool> {
+    pub fn find_swarm_by_host(&self, host: &str) -> Option<&RemoteStack> {
         let pos = self.stacks.iter().position(|s| s.host == host);
         if let None = pos {
-            return Err(false);
+            return None;
         }
         let pos = pos.unwrap();
 
         let swarm = &self.stacks[pos];
 
-        Ok(swarm)
+        Some(swarm)
     }
 }

--- a/src/bin/super/state.rs
+++ b/src/bin/super/state.rs
@@ -106,4 +106,15 @@ impl Super {
 
         Some(swarm)
     }
+
+    pub fn delete_swarm_by_host(&mut self, host: &str) -> Result<(), String> {
+        let initial_len = self.stacks.len();
+        self.stacks.retain(|stack| stack.host != host);
+
+        if self.stacks.len() == initial_len {
+            Err(format!("Host '{}' does not exist.", host))
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/src/bin/super/state.rs
+++ b/src/bin/super/state.rs
@@ -90,4 +90,8 @@ impl Super {
             bots: bots,
         }
     }
+
+    pub fn add_remote_stack(&mut self, new_stack: RemoteStack) {
+        self.stacks.push(new_stack);
+    }
 }

--- a/src/bin/super/state.rs
+++ b/src/bin/super/state.rs
@@ -94,4 +94,16 @@ impl Super {
     pub fn add_remote_stack(&mut self, new_stack: RemoteStack) {
         self.stacks.push(new_stack);
     }
+
+    pub fn find_swarm_by_host(&self, host: &str) -> Result<&RemoteStack, bool> {
+        let pos = self.stacks.iter().position(|s| s.host == host);
+        if let None = pos {
+            return Err(false);
+        }
+        let pos = pos.unwrap();
+
+        let swarm = &self.stacks[pos];
+
+        Ok(swarm)
+    }
 }

--- a/src/bin/super/superapp/src/App.svelte
+++ b/src/bin/super/superapp/src/App.svelte
@@ -4,6 +4,16 @@
   import { activeUser, saveUserToStore, logoutUser } from "./store";
   import User from "carbon-icons-svelte/lib/User.svelte";
   import { OverflowMenu, OverflowMenuItem } from "carbon-components-svelte";
+  import ChangePassword from "./ChangePassword.svelte";
+  let page = "main";
+
+  async function backToMain() {
+    page = "main";
+  }
+
+  function handleChangePassword() {
+    page = "change_password";
+  }
 </script>
 
 <main>
@@ -18,11 +28,19 @@
       <section class="menu-btn">
         <OverflowMenu icon={User} flipped>
           <OverflowMenuItem on:click={logoutUser} text="Logout" />
+          <OverflowMenuItem
+            on:click={handleChangePassword}
+            text="Change Password"
+          />
         </OverflowMenu>
       </section>
     </header>
     <div class="body">
-      <Remotes />
+      {#if page === "change_password"}
+        <ChangePassword back={backToMain} />
+      {:else}
+        <Remotes />
+      {/if}
     </div>
   {/if}
 </main>

--- a/src/bin/super/superapp/src/ChangePassword.svelte
+++ b/src/bin/super/superapp/src/ChangePassword.svelte
@@ -1,0 +1,160 @@
+<script>
+  import {
+    Button,
+    TextInput,
+    Loading,
+    Form,
+    InlineNotification,
+  } from "carbon-components-svelte";
+  import Icon from "carbon-icons-svelte/lib/Password.svelte";
+  import ArrowLeft from "carbon-icons-svelte/lib/ArrowLeft.svelte";
+  import * as api from "../../../../../app/src/api";
+  import { activeUser, logoutUser } from "./store";
+
+  export let back = () => {};
+
+  $: old_pass = "";
+  $: password = "";
+  $: confirm_pass = "";
+  let show_notification = false;
+
+  $: addDisabled =
+    !old_pass || !password || !confirm_pass || password !== confirm_pass;
+
+  let loading = false;
+
+  async function change() {
+    try {
+      loading = true;
+
+      const result = await api.swarm.update_password(
+        password,
+        old_pass,
+        $activeUser
+      );
+
+      if (result) {
+        show_notification = true;
+
+        old_pass = "";
+        password = "";
+        confirm_pass = "";
+      }
+      loading = false;
+      setTimeout(() => {
+        back();
+        logoutUser();
+      }, 3000);
+    } catch (_) {
+      loading = false;
+    }
+  }
+</script>
+
+<main>
+  <div class="back" on:click={back} on:keypress={() => {}}>
+    <ArrowLeft size={32} />
+  </div>
+  <div class="container">
+    {#if loading}
+      <Loading />
+    {:else}
+      <section class="login-wrap">
+        <h3 class="header-text">Change your password</h3>
+
+        {#if show_notification}
+          <InlineNotification
+            lowContrast
+            kind="success"
+            title="Success:"
+            subtitle="Your password has been changed."
+            timeout={3000}
+            on:close={(e) => {
+              e.preventDefault();
+              show_notification = false;
+            }}
+          />
+        {/if}
+
+        <Form on:submit>
+          <div class="input_container">
+            <TextInput
+              labelText={"Old Password"}
+              placeholder={"Enter your old password"}
+              type="password"
+              bind:value={old_pass}
+            />
+          </div>
+          <div class="input_container">
+            <TextInput
+              labelText={"New Password"}
+              placeholder={"Enter your new password"}
+              type="password"
+              bind:value={password}
+            />
+          </div>
+
+          <div class="input_container">
+            <TextInput
+              labelText={"Confirm Password"}
+              placeholder={"Confirm your password"}
+              type="password"
+              bind:value={confirm_pass}
+            />
+          </div>
+          <div class="btn-container">
+            <Button
+              disabled={addDisabled}
+              on:click={change}
+              class="peer-btn"
+              size="field"
+              type="submit"
+              icon={Icon}>Change Password</Button
+            >
+          </div>
+        </Form>
+      </section>
+    {/if}
+  </div>
+</main>
+
+<!-- on:click={change} -->
+
+<style>
+  main {
+    height: 100%;
+    width: 100%;
+    background: #1a242e;
+  }
+  .container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 85%;
+  }
+  .login-wrap {
+    width: 35vw;
+    text-align: left;
+  }
+  .header-text {
+    font-size: 1.25rem;
+    font-size: 900;
+    margin-bottom: 35px;
+  }
+  .back {
+    margin-top: 25px;
+    margin-left: 2.5rem;
+    cursor: pointer;
+  }
+
+  .input_container {
+    margin-bottom: 1.5rem;
+  }
+
+  .btn-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -8,6 +8,7 @@
     Modal,
     TextInput,
     ToastNotification,
+    InlineNotification,
   } from "carbon-components-svelte";
   import Healthcheck from "./Healthcheck.svelte";
   import UploadIcon from "carbon-icons-svelte/lib/Upload.svelte";
@@ -25,6 +26,7 @@
   let show_notification = false;
   let message = "";
   let isSubmitting = false;
+  let error_notification = false;
 
   let selectedRowIds = [];
 
@@ -118,21 +120,27 @@
 
     //send data to backened
     const response = await api.swarm.add_new_swarm(data);
-    if (response.success) {
+    if (response.success === "true") {
       //get config again
       await getConfigSortByUnhealthy();
+
       //clear host, instance, description
       new_host = "";
       new_description = "";
       new_instance = "";
       isSubmitting = false;
+
       //close modal
       open = false;
+
       //add notification for success
       show_notification = true;
-      message = "Swarms added successfully";
+      message = response.message;
+    } else {
+      isSubmitting = false;
+      message = response.message;
+      error_notification = true;
     }
-    isSubmitting = false;
   }
 </script>
 
@@ -201,6 +209,18 @@
     on:close
     on:submit={handleSubmitAddSwarm}
   >
+    {#if error_notification}
+      <InlineNotification
+        kind="error"
+        title="Error:"
+        subtitle={message}
+        timeout={3000}
+        on:close={(e) => {
+          e.preventDefault();
+          error_notification = false;
+        }}
+      />
+    {/if}
     <p>Add a new swarm to the list of swarms.</p>
     <div class="text_input_container">
       <TextInput

--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -147,6 +147,11 @@
   }
 
   async function handleSubmitAddSwarm() {
+    if (!host) {
+      message = "Host is a required field";
+      error_notification = true;
+      return;
+    }
     isSubmitting = true;
 
     //send data to backened

--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -28,6 +28,7 @@
   let isSubmitting = false;
   let error_notification = false;
   let isUpdate = false;
+  let swarm_id = "";
 
   let selectedRowIds = [];
 
@@ -113,16 +114,23 @@
 
   async function handleSubmitAddSwarm() {
     isSubmitting = true;
-    const data = {
-      host: host,
-      instance: instance,
-      description: description,
-    };
 
     //send data to backened
     let response;
     if (isUpdate) {
+      const data = {
+        id: swarm_id,
+        host: host,
+        instance: instance,
+        description: description,
+      };
+      response = await api.swarm.update_swarm_details(data);
     } else {
+      const data = {
+        host: host,
+        instance: instance,
+        description: description,
+      };
       response = await api.swarm.add_new_swarm(data);
     }
     message = response?.message;
@@ -151,6 +159,7 @@
     instance = "";
     description = "";
     isUpdate = false;
+    swarm_id = "";
   }
 
   function findSwarm(id: string) {
@@ -172,6 +181,7 @@
       host = swarm.host;
       description = swarm.note;
       instance = swarm.ec2;
+      swarm_id = id;
     }
   }
 

--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -5,6 +5,8 @@
     Toolbar,
     ToolbarContent,
     ToolbarSearch,
+    Modal,
+    TextInput,
   } from "carbon-components-svelte";
   import Healthcheck from "./Healthcheck.svelte";
   import UploadIcon from "carbon-icons-svelte/lib/Upload.svelte";
@@ -14,6 +16,11 @@
   import { onMount } from "svelte";
   import type { Remote } from "./types/types";
   import { splitHost } from "./utils/index";
+
+  let open = false;
+  let new_host = "";
+  let new_description = "";
+  let new_instance = "";
 
   let selectedRowIds = [];
 
@@ -67,8 +74,8 @@
     return () => clearInterval(interval);
   });
 
-  function something() {
-    console.log("something");
+  function openAddSwarmModal() {
+    open = true;
   }
 
   async function getTribes(r: Remote[]) {
@@ -100,6 +107,20 @@
   function remoterow(r: Remote) {
     return { ...r, id: r.host };
   }
+
+  function handleSubmitAddSwarm() {
+    const data = {
+      host: new_host,
+      intance: new_instance,
+      description: new_description,
+    };
+
+    console.log(data);
+    //send data to backened
+    //get config again
+    //clear host, instance, description
+    //add notification for success
+  }
 </script>
 
 <main>
@@ -123,8 +144,8 @@
             <ToolbarMenuItem hasDivider>API documentation</ToolbarMenuItem>
             <ToolbarMenuItem hasDivider>Stop all</ToolbarMenuItem>
           </ToolbarMenu> -->
-        <Button kind="tertiary" on:click={something} icon={UploadIcon}>
-          Do something
+        <Button kind="tertiary" on:click={openAddSwarmModal} icon={UploadIcon}>
+          Add New Swarm
         </Button>
       </ToolbarContent>
     </Toolbar>
@@ -138,6 +159,44 @@
       {/if}
     </svelte:fragment>
   </DataTable>
+
+  <Modal
+    bind:open
+    modalHeading="Add new Swarm"
+    primaryButtonText="Confirm"
+    secondaryButtonText="Cancel"
+    selectorPrimaryFocus="#db-name"
+    on:click:button--secondary={() => (open = false)}
+    on:open
+    on:close
+    on:submit={handleSubmitAddSwarm}
+  >
+    <p>Add a new swarm to the list of swarms.</p>
+    <div class="text_input_container">
+      <TextInput
+        id="host"
+        labelText="Host"
+        placeholder="Enter Swarm Host..."
+        bind:value={new_host}
+      />
+    </div>
+    <div class="text_input_container">
+      <TextInput
+        id="description"
+        labelText="Description"
+        placeholder="Enter Swarm Description..."
+        bind:value={new_description}
+      />
+    </div>
+    <div class="text_input_container">
+      <TextInput
+        id="instance"
+        labelText="Instance"
+        placeholder="Enter Swarm Instance Size..."
+        bind:value={new_instance}
+      />
+    </div>
+  </Modal>
 </main>
 
 <style>
@@ -145,5 +204,9 @@
     overflow: auto;
     max-height: var(--body-height);
     width: 100%;
+  }
+
+  .text_input_container {
+    margin-top: 1rem;
   }
 </style>


### PR DESCRIPTION
Allow Super admin perform CRUD operations on Swarm Superadmin Dashboard.

Such as:
* Adding a new Swarm to dashboard.
* Editing a Swarm on dashbpard.
* Deleting a Swarm from dashboard.

Also, allow super admin to change password