### PR TITLE
fix: use getconfig to display swarms instead of getConfigSortByUnhealthy

### DIFF
--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -77,8 +77,10 @@
     }
   }
 
-  onMount(() => {
-    getConfigSortByUnhealthy();
+  onMount(async () => {
+    await getConfig();
+
+    await getConfigSortByUnhealthy();
   });
 
   function openAddSwarmModal() {
@@ -98,7 +100,7 @@
       });
       message = response?.message;
       if (response?.success === "true") {
-        await getConfigSortByUnhealthy();
+        await getConfig();
       } else {
         errorMessage = true;
       }
@@ -176,7 +178,7 @@
 
     if (response?.success === "true") {
       //get config again
-      await getConfigSortByUnhealthy();
+      await getConfig();
 
       //clear host, instance, description
       clear_swarm_data();


### PR DESCRIPTION
When using `getConfigSortByUnhealthy` to get swarms, if one of the swarms is taking long to respond when getting stats the data is not displayed on the table.

But with `getConfig` we get directly from the backend and display on the table before we try to get the swarm status