### PR TITLE
fix: added a route prefix for anything but api

### DIFF
--- a/src/images/traefik.rs
+++ b/src/images/traefik.rs
@@ -148,7 +148,7 @@ pub fn traefik_labels(
         if name == "navfiber" {
             // anything except /api (local resources)
             def.push(format!(
-                "traefik.http.routers.{}.rule=Host(`{}`)",
+                "traefik.http.routers.{}.rule=Host(`{}`) && PathRegexp(`^(?!/api).*`)",
                 name, shared_host
             ));
             def.push(format!("traefik.http.routers.{}.priority=1", name));


### PR DESCRIPTION
This was created because of this issue https://github.com/stakwork/jarvis-backend/issues/1774

This should make it such that if a user goes into that path if it doesnt include `api` in the prefix then it will just go to the home page