### PR TITLE
feat: allows us to copy the txid of a channel we just funded

### DIFF
--- a/app/src/lnd/ChannelRows.svelte
+++ b/app/src/lnd/ChannelRows.svelte
@@ -75,9 +75,13 @@
   let show_notification = false;
 
   function clickRow(chan) {
-    if (!chan.active) return;
-    copyText(chan.remote_pubkey)
-    toast.success("Pubkey copied")
+    if (!chan.active && type === "Cln") {
+      copyText(chan.channel_point);
+      toast.success("Funding Txid copied");
+      return;
+    }
+    copyText(chan.remote_pubkey);
+    toast.success("Pubkey copied");
     if (selectedChannelParter === chan.remote_pubkey) {
       selectedChannelParter = "";
       forceCloseDestination = "";


### PR DESCRIPTION
closes https://github.com/stakwork/sphinx-swarm/issues/482

This should grab the txid of a funded channel

PSA I have not tested this, will test it when I need to open a new channel