### PR TITLE
Hide deleted swarm

### DIFF
--- a/src/bin/super/mod.rs
+++ b/src/bin/super/mod.rs
@@ -195,7 +195,7 @@ pub async fn super_handle(
                     private_ip_address: Some("".to_string()),
                     id: None,
                     deleted: Some(false),
-                    route53_ids: None,
+                    route53_domain_names: None,
                 };
 
                 let hm = add_new_swarm_details(&mut state, swarm_detail, &mut must_save_stack);
@@ -218,7 +218,7 @@ pub async fn super_handle(
                             private_ip_address: state.stacks[ui].private_ip_address.clone(),
                             id: state.stacks[ui].id.clone(),
                             deleted: state.stacks[ui].deleted.clone(),
-                            route53_ids: state.stacks[ui].route53_ids.clone(),
+                            route53_domain_names: state.stacks[ui].route53_domain_names.clone(),
                         };
                         must_save_stack = true;
                         hm = AddSwarmResponse {
@@ -264,7 +264,7 @@ pub async fn super_handle(
                     private_ip_address: Some("".to_string()),
                     id: None,
                     deleted: Some(false),
-                    route53_ids: None,
+                    route53_domain_names: None,
                 };
                 let hm =
                     add_new_swarm_from_child_swarm(&mut state, swarm_details, &mut must_save_stack);

--- a/src/bin/super/mod.rs
+++ b/src/bin/super/mod.rs
@@ -194,6 +194,8 @@ pub async fn super_handle(
                     public_ip_address: Some("".to_string()),
                     private_ip_address: Some("".to_string()),
                     id: None,
+                    deleted: Some(false),
+                    route53_ids: None,
                 };
 
                 let hm = add_new_swarm_details(&mut state, swarm_detail, &mut must_save_stack);
@@ -215,6 +217,8 @@ pub async fn super_handle(
                             public_ip_address: state.stacks[ui].public_ip_address.clone(),
                             private_ip_address: state.stacks[ui].private_ip_address.clone(),
                             id: state.stacks[ui].id.clone(),
+                            deleted: state.stacks[ui].deleted.clone(),
+                            route53_ids: state.stacks[ui].route53_ids.clone(),
                         };
                         must_save_stack = true;
                         hm = AddSwarmResponse {
@@ -259,6 +263,8 @@ pub async fn super_handle(
                     public_ip_address: Some("".to_string()),
                     private_ip_address: Some("".to_string()),
                     id: None,
+                    deleted: Some(false),
+                    route53_ids: None,
                 };
                 let hm =
                     add_new_swarm_from_child_swarm(&mut state, swarm_details, &mut must_save_stack);

--- a/src/bin/super/state.rs
+++ b/src/bin/super/state.rs
@@ -28,6 +28,8 @@ pub struct RemoteStack {
     pub public_ip_address: Option<String>,
     pub private_ip_address: Option<String>,
     pub id: Option<String>,
+    pub deleted: Option<bool>,
+    pub route53_ids: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
@@ -134,6 +136,8 @@ impl Super {
                 public_ip_address: n.public_ip_address.clone(),
                 private_ip_address: n.private_ip_address.clone(),
                 id: n.id.clone(),
+                deleted: n.deleted.clone(),
+                route53_ids: n.route53_ids.clone(),
             })
             .collect();
         let bots = self

--- a/src/bin/super/state.rs
+++ b/src/bin/super/state.rs
@@ -29,7 +29,7 @@ pub struct RemoteStack {
     pub private_ip_address: Option<String>,
     pub id: Option<String>,
     pub deleted: Option<bool>,
-    pub route53_ids: Option<Vec<String>>,
+    pub route53_domain_names: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
@@ -138,7 +138,7 @@ impl Super {
                 private_ip_address: n.private_ip_address.clone(),
                 id: n.id.clone(),
                 deleted: n.deleted.clone(),
-                route53_ids: n.route53_ids.clone(),
+                route53_domain_names: n.route53_domain_names.clone(),
             })
             .collect();
         let bots = self

--- a/src/bin/super/state.rs
+++ b/src/bin/super/state.rs
@@ -125,6 +125,7 @@ impl Super {
         let stacks = self
             .stacks
             .iter()
+            .filter(|s| s.deleted == Some(false))
             .map(|n| RemoteStack {
                 host: n.host.clone(),
                 note: n.note.clone(),

--- a/src/bin/super/superapp/src/Healthcheck.svelte
+++ b/src/bin/super/superapp/src/Healthcheck.svelte
@@ -3,6 +3,7 @@
   import WarningFilled from "carbon-icons-svelte/lib/WarningFilled.svelte";
 
   import { onMount } from "svelte";
+  import { getRemoteByHost } from "./utils";
 
   export let host = "";
 
@@ -10,11 +11,16 @@
   let status: Status = "checking";
 
   async function checkStatus() {
+    const swarm = getRemoteByHost(host);
     try {
       let url = `https://boltwall.${host}/stats`;
       // custom URLs
       if (!/swarm\d+/.test(host)) {
         url = `https://${host}/api/stats`;
+      }
+
+      if (swarm && swarm.default_host.endsWith(":8800")) {
+        url = `https://${swarm.host}:8444/stats`;
       }
       console.log("URL", url);
       const r = await fetch(url);

--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -21,11 +21,14 @@
   import UploadIcon from "carbon-icons-svelte/lib/Upload.svelte";
   import Tribes from "./Tribes.svelte";
   import * as api from "../../../../../app/src/api";
-  import { remotes } from "./store";
+  import { remotes, selectedNode } from "./store";
   import { onMount } from "svelte";
   import type { Remote } from "./types/types";
-  import { getSwarmNumber, isValidVanityAddress } from "./utils/index";
-  import { selectedNode } from "./store";
+  import {
+    getRemoteByHost,
+    getSwarmNumber,
+    isValidVanityAddress,
+  } from "./utils/index";
   import {
     create_new_swarm_ec2,
     get_child_swarm_config,
@@ -85,9 +88,12 @@
           if (!/swarm\d+/.test(host)) {
             url = `https://${host}/api/stats`;
           }
+          if (el.default_host.endsWith(":8800")) {
+            url = `https://${el.host}:8444/stats`;
+          }
           console.log("URL", url);
           const r = await fetch(url);
-          await r.json();
+          const data = await r.json();
           healthyRemotes.push(el);
         } catch (e) {
           console.warn(e);
@@ -379,16 +385,15 @@
   }
 
   function getSwarmAdminUrl(host: string) {
-    for (let i = 0; i < $remotes.length; i++) {
-      const remote = $remotes[i];
-      if (remote.host === host) {
-        if (remote.default_host.endsWith(":8800")) {
-          return `https://${remote.default_host}`;
-        } else {
-          return `https://app.${remote.default_host}`;
-        }
+    const swarm = getRemoteByHost(host);
+    if (swarm) {
+      if (swarm.default_host.endsWith(":8800")) {
+        return `https://${swarm.default_host}`;
+      } else {
+        return `https://app.${swarm.default_host}`;
       }
     }
+
     return "";
   }
 </script>

--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -466,7 +466,7 @@
             {cell.value}
           </p>
           <Link target={"_blank"} href={getSwarmAdminUrl(row.id)}
-            >Visit Swarm Admin</Link
+            >Visit Swarm Dashboard</Link
           >
         </div>
       {:else if cell.key === "tribes"}

--- a/src/bin/super/superapp/src/Remotes.svelte
+++ b/src/bin/super/superapp/src/Remotes.svelte
@@ -13,6 +13,7 @@
     Select,
     SelectItem,
     Checkbox,
+    Link,
   } from "carbon-components-svelte";
   import { UpdateNow, Stop } from "carbon-icons-svelte";
 
@@ -121,7 +122,9 @@
 
   function remoterow(r: Remote) {
     let swarmNumber = "";
-    if (r.default_host) {
+    if (r.id) {
+      swarmNumber = getSwarmNumber(r.id);
+    } else if (r.default_host) {
       swarmNumber = getSwarmNumber(r.default_host);
     }
     return { ...r, id: r.host, number: swarmNumber };
@@ -374,6 +377,20 @@
       swarm_name_width = max_input_with;
     }
   }
+
+  function getSwarmAdminUrl(host: string) {
+    for (let i = 0; i < $remotes.length; i++) {
+      const remote = $remotes[i];
+      if (remote.host === host) {
+        if (remote.default_host.endsWith(":8800")) {
+          return `https://${remote.default_host}`;
+        } else {
+          return `https://app.${remote.default_host}`;
+        }
+      }
+    }
+    return "";
+  }
 </script>
 
 <main>
@@ -439,9 +456,14 @@
       {:else if cell.key === "tribes"}
         <Tribes host={row.id} />
       {:else if cell.key === "host"}
-        <p class="host_name" on:click={() => handleViewNodes(row.id)}>
-          {cell.value}
-        </p>
+        <div class="host_name_container">
+          <p class="host_name" on:click={() => handleViewNodes(row.id)}>
+            {cell.value}
+          </p>
+          <Link target={"_blank"} href={getSwarmAdminUrl(row.id)}
+            >Visit Swarm Admin</Link
+          >
+        </div>
       {:else if cell.key === "tribes"}
         <Tribes host={row.id} />
       {:else}
@@ -622,5 +644,11 @@
 
   .checkbox_container {
     margin-top: 1rem;
+  }
+
+  .host_name_container {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
   }
 </style>

--- a/src/bin/super/superapp/src/types/types.ts
+++ b/src/bin/super/superapp/src/types/types.ts
@@ -37,6 +37,7 @@ export interface Remote {
   default_host?: string;
   ec2_instance_id: string;
   public_ip_address?: string;
+  id?: string;
 }
 
 export interface ILightningBot {

--- a/src/bin/super/superapp/src/utils/index.ts
+++ b/src/bin/super/superapp/src/utils/index.ts
@@ -1,6 +1,8 @@
 import type { ILightningBot } from "../types/types";
 import type { Writable } from "svelte/store";
+import { get } from "svelte/store";
 import { get_lightning_bots_detail } from "../../../../../../app/src/api/swarm";
+import { remotes } from "../store";
 
 export function splitHost(hostFullPath: string) {
   if (hostFullPath) {
@@ -70,4 +72,15 @@ export async function fectAndRefreshLightningBotDetails(
       message: "Error occured while trying to get lightning bots details",
     };
   }
+}
+
+export function getRemoteByHost(host: string) {
+  const swarms = get(remotes);
+  for (let i = 0; i < swarms.length; i++) {
+    const remote = swarms[i];
+    if (remote.host === host) {
+      return remote;
+    }
+  }
+  return null;
 }

--- a/src/bin/super/util.rs
+++ b/src/bin/super/util.rs
@@ -1202,6 +1202,9 @@ pub async fn get_config(state: &mut Super) -> Result<Super, Error> {
 
     for stack in state.stacks.iter_mut() {
         if aws_instances_hashmap.contains_key(&stack.ec2_instance_id) {
+            if stack.deleted.is_none() || stack.deleted.unwrap() == true {
+                stack.deleted = Some(false);
+            }
             let aws_instance_hashmap = aws_instances_hashmap.get(&stack.ec2_instance_id).unwrap();
             stack.public_ip_address = Some(aws_instance_hashmap.public_ip_address.clone());
             stack.private_ip_address = Some(aws_instance_hashmap.private_ip_address.clone());
@@ -1212,6 +1215,9 @@ pub async fn get_config(state: &mut Super) -> Result<Super, Error> {
                     stack.ec2 = Some(aws_instance_hashmap.instance_type.clone())
                 }
             }
+        } else {
+            // If we don't find the isnatnce in the AWS response, we can mark as deleted
+            stack.deleted = Some(true)
         }
     }
     let res = state.remove_tokens();

--- a/src/bin/super/util.rs
+++ b/src/bin/super/util.rs
@@ -901,6 +901,8 @@ pub async fn create_swarm_ec2(
         public_ip_address: Some("".to_string()),
         private_ip_address: Some("".to_string()),
         id: Some(swarm_id.clone()),
+        deleted: Some(false),
+        route53_ids: None,
     };
 
     state.add_remote_stack(new_swarm);

--- a/src/bin/super/util.rs
+++ b/src/bin/super/util.rs
@@ -883,7 +883,7 @@ pub async fn create_swarm_ec2(
 
     let ec2_ip_address = get_instance_ip(&ec2_intance.0).await?;
 
-    let _ = add_domain_name_to_route53(domain_names, &ec2_ip_address).await?;
+    let _ = add_domain_name_to_route53(domain_names.clone(), &ec2_ip_address).await?;
 
     log::info!("Public_IP: {}", ec2_ip_address);
 
@@ -902,7 +902,7 @@ pub async fn create_swarm_ec2(
         private_ip_address: Some("".to_string()),
         id: Some(swarm_id.clone()),
         deleted: Some(false),
-        route53_ids: None,
+        route53_domain_names: Some(domain_names),
     };
 
     state.add_remote_stack(new_swarm);


### PR DESCRIPTION
**PR Summary:**

1. Mark swarms not present on EC2 as deleted.
2. After marking as deleted, remove their domain records from Route 53.
3. Add a "Visit Swarm Dashboard" link in the swarm list table.
4. Ensure boltwall is called with the correct URL based on the new `port_based_ssl` setting.
