### PR TITLE
chore: get version for images hosted on Github Containter Registry

### DIFF
--- a/src/dock.rs
+++ b/src/dock.rs
@@ -737,9 +737,10 @@ pub async fn get_image_version_from_digest(image_name: &str, digest: &str) -> St
             return "".to_string();
         }
         let github_container_name = image_name_parts[2];
+        let org_name = image_name_parts[1];
         let url = format!(
-            "https://api.github.com/orgs/stakwork/packages/container/{}/versions",
-            github_container_name,
+            "https://api.github.com/orgs/{}/packages/container/{}/versions",
+            org_name, github_container_name,
         );
         return get_version_from_github_container_registry(&url, digest).await;
     }


### PR DESCRIPTION
### Before
<img width="1509" height="744" alt="Screenshot 2025-08-15 at 03 06 27" src="https://github.com/user-attachments/assets/0e615b66-eeee-42a8-8d70-45d36f707c26" />

### After
<img width="1509" height="746" alt="Screenshot 2025-08-15 at 03 02 51" src="https://github.com/user-attachments/assets/e0e53fe5-99c0-413d-b68e-770e4f55b392" />
