### PR TITLE
Fix EC2 password environment variable not being passed to container

### DIFF
--- a/second-brain-2.yml
+++ b/second-brain-2.yml
@@ -119,6 +119,7 @@ services:
       - ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
       - OPENAI_API_KEY=$OPENAI_API_KEY
       - GITHUB_PAT=$GITHUB_PAT
+      - PASSWORD=$PASSWORD
   node_exporter:
     image: quay.io/prometheus/node-exporter:latest
     container_name: node_exporter


### PR DESCRIPTION
The PASSWORD environment variable was being written to .env file during EC2 instance creation but was not being passed through to the sphinx-swarm container in the docker-compose configuration.

Added PASSWORD=$PASSWORD to the environment section in second-brain-2.yml so that custom passwords specified during swarm creation are properly applied to the admin user.