### PR TITLE
fix: use the 8444 port for boltwall since we've now switched to port

### DIFF
--- a/src/bin/super/checker.rs
+++ b/src/bin/super/checker.rs
@@ -117,13 +117,13 @@ fn get_boltwall_and_navfiber_url(host: String) -> Result<(String, String)> {
     if subdomain.starts_with("swarm") && is_numeric(&subdomain[5..]) {
         return Ok((
             format!("https://nav.{}/", host.clone()),
-            format!("https://boltwall.{}/api/", host.clone()),
+            format!("https://{}:8444/api/", host.clone()),
         ));
     }
 
     return Ok((
-        format!("https://{}/", host),
-        format!("https://{}/api/", host),
+        format!("https://{}:8444/", host),
+        format!("https://{}:8444/api/", host),
     ));
 }
 


### PR DESCRIPTION
## Desc
I was seeing these logs in the super admin logs and I think they might be the reason why super admins poll endpoint is hanging right now
```
2025-08-20 19:39:13,382 ERROR [super::checker] Error: error sending request for url (https://workspace61.sphinx.chat/api/): operation timed out
2025-08-20 19:39:33,385 ERROR [super::checker] Error: error sending request for url (https://workspace61.sphinx.chat/api/stats): operation timed out
2025-08-20 19:39:53,386 ERROR [super::checker] Error: error sending request for url (https://workspace61.sphinx.chat/): operation timed out
```

## Fix
I supsect it was because now that we have moved to port based routing on swarm when we reference boltwall with boltwall.xxx.xxx instead of xxx.xxx:8444 it will not respond and time out.

This is hardcoding 8444 as the port but it should resolve the issue currently