### PR TITLE
added aws log groups by swarm id

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,5 +61,4 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache" \
           --platform linux/amd64 \
           --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-swarm:${{ env.RELEASE_TAG }}" \
-          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-swarm:latest" \
           --output "type=registry" ./

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,4 +61,5 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache" \
           --platform linux/amd64 \
           --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-swarm:${{ env.RELEASE_TAG }}" \
+          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-swarm:latest" \
           --output "type=registry" ./

--- a/second-brain.yml
+++ b/second-brain.yml
@@ -39,9 +39,6 @@ services:
       - /home/admin/letsencrypt:/letsencrypt
     environment:
       - AWS_REGION=$AWS_REGION
-    logging:
-      options:
-        max-size: 10m
 
   sphinx-swarm:
     image: sphinxlightning/sphinx-swarm

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,6 +23,8 @@ pub fn host_config(
     mem_limit: Option<i64>,
 ) -> Option<HostConfig> {
     let mut dvols = vec![volume_string(name, root_vol)];
+    let swarm_number = getenv("SWARM_NUMBER").unwrap_or("".to_string());
+
     if let Some(evs) = extra_vols {
         dvols.extend(evs);
     }
@@ -35,7 +37,7 @@ pub fn host_config(
             name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),
             maximum_retry_count: None,
         }),
-        log_config: local_log_config(SWARM_ID_HERE),
+        log_config: local_log_config(&swarm_number),
         ..Default::default()
     };
     if let Some(ml) = mem_limit {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,7 +35,7 @@ pub fn host_config(
             name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),
             maximum_retry_count: None,
         }),
-        log_config: local_log_config(),
+        log_config: local_log_config(SWARM_ID_HERE),
         ..Default::default()
     };
     if let Some(ml) = mem_limit {
@@ -59,12 +59,17 @@ pub fn add_gpus_to_host_config(hc: &mut HostConfig, count: i64) {
     }]);
 }
 
-fn local_log_config() -> Option<HostConfigLogConfig> {
+fn local_log_config(swarm_id: &str) -> Option<HostConfigLogConfig> {
     let mut h = HashMap::new();
-    h.insert("max-size".to_string(), "10m".to_string());
-    h.insert("max-file".to_string(), "5".to_string());
+    h.insert("awslogs-region".to_string(), "us-east-1".to_string());
+    h.insert("awslogs-group".to_string(), format!("/swarms/{}", swarm_id));
+    h.insert("awslogs-create-group".to_string(), "true".to_string());
+    h.insert("tag".to_string(), "{{.Name}}".to_string());
+    // Optional: customize local cache
+    h.insert("cache-max-size".to_string(), "10m".to_string());
+    h.insert("cache-max-file".to_string(), "3".to_string());
     Some(HostConfigLogConfig {
-        typ: Some("local".to_string()),
+        typ: Some("awslogs".to_string()),
         config: Some(h),
     })
 }


### PR DESCRIPTION
@tobi-bams @Evanfeenstra I want to add this change but not sure how to finish it, I need to pass the SwarmID, as in "swarm-1234" where it says SWARM_ID_HERE, that will allow us to see the log group in CloudWatch, can you guys help me finish this? I can test it if you guys create a release I can use.

Thanks