### PR TITLE
feat: update the swarm number to be alpha numeric and 6 chars

### DIFF
--- a/src/bin/super/util.rs
+++ b/src/bin/super/util.rs
@@ -42,6 +42,7 @@ use crate::state::{self, AwsInstanceType, RemoteStack, Super};
 use aws_config::timeout::TimeoutConfig;
 use aws_sdk_ec2::types::IamInstanceProfileSpecification;
 use rand::Rng;
+use rand::distributions::Alphanumeric;
 use tokio::time::{sleep, Duration};
 
 pub fn add_new_swarm_details(
@@ -445,7 +446,11 @@ pub async fn create_ec2_instance(
 
     let super_token = getenv("SUPER_TOKEN")?;
 
-    let swarm_number = rand::thread_rng().gen_range(100000..1000000);
+    let swarm_number: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(6)
+        .map(char::from)
+        .collect();
 
     let swarm_name = swarm_name.unwrap_or_else(|| format!("swarm{}", swarm_number));
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -431,7 +431,11 @@ pub fn getenv(envname: &str) -> Result<String> {
 }
 
 pub fn extract_swarm_number(host: String) -> String {
-    host.chars().filter(|c| c.is_numeric()).collect()
+    if let Some(pos) = host.find("swarm") {
+        host[pos + 5..].to_string()
+    } else {
+        String::new()
+    }
 }
 
 pub fn update_or_write_to_env_file(updates: &HashMap<String, String>) -> Result<()> {


### PR DESCRIPTION
## Description
This change is meant to make the swarm number alphanumeric, 6 characters instead of just 6 integers, since there is a high likelihood of swarms having the same number.