### PR TITLE
Generated with Hive: Set 7-day CloudWatch log group retention on EC2 instance creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ futures = "*"
 aws-sdk-ec2 = "1.72.0"
 aws-sdk-route53 = "1.45.0"
 aws-sdk-cloudwatch = "1"
+aws-sdk-cloudwatchlogs = "1"
 aws-sdk-sns = "1"
 
 [lib]

--- a/src/bin/super/cloudwatch.rs
+++ b/src/bin/super/cloudwatch.rs
@@ -4,6 +4,7 @@ use aws_config::Region;
 use aws_sdk_cloudwatch::types::ComparisonOperator;
 use aws_sdk_cloudwatch::types::{Dimension, StandardUnit, Statistic};
 use aws_sdk_cloudwatch::Client as CloudWatchClient;
+use aws_sdk_cloudwatchlogs::Client as CloudWatchLogsClient;
 use aws_sdk_sns::Client as SnsClient;
 use sphinx_swarm::utils::getenv;
 
@@ -12,6 +13,26 @@ async fn make_cloudwatch_client() -> Result<CloudWatchClient, Error> {
     let region_provider = RegionProviderChain::first_try(Some(Region::new(region)));
     let config = aws_config::from_env().region(region_provider).load().await;
     Ok(CloudWatchClient::new(&config))
+}
+
+async fn make_cloudwatch_logs_client() -> Result<CloudWatchLogsClient, Error> {
+    let region = getenv("AWS_REGION")?;
+    let region_provider = RegionProviderChain::first_try(Some(Region::new(region)));
+    let config = aws_config::from_env().region(region_provider).load().await;
+    Ok(CloudWatchLogsClient::new(&config))
+}
+
+pub async fn set_log_group_retention(log_group_name: &str) -> Result<(), Error> {
+    let client = make_cloudwatch_logs_client().await?;
+    client
+        .put_retention_policy()
+        .log_group_name(log_group_name)
+        .retention_in_days(7)
+        .send()
+        .await
+        .map_err(|e| anyhow!(e.to_string()))?;
+    log::info!("Set 7-day retention on log group {}", log_group_name);
+    Ok(())
 }
 
 async fn make_sns_client() -> Result<SnsClient, Error> {

--- a/src/bin/super/util.rs
+++ b/src/bin/super/util.rs
@@ -766,6 +766,15 @@ pub async fn create_ec2_instance(
                 }
             }
 
+            let log_group = format!("/swarms/{}", swarm_number);
+            if let Err(e) = crate::cloudwatch::set_log_group_retention(&log_group).await {
+                log::warn!(
+                    "Failed to set log group retention for {}: {}",
+                    log_group,
+                    e
+                );
+            }
+
             return Ok(CreateSwarmEc2Instance {
                 ec2_instance_id: instance_id,
                 swarm_number: swarm_number.to_string(),


### PR DESCRIPTION
Generated with Hive: Set 7-day CloudWatch log group retention on EC2 instance creation