### PR TITLE
Fix CLN channel confirmations on regtest

### DIFF
--- a/app/src/api/btc.ts
+++ b/app/src/api/btc.ts
@@ -19,6 +19,11 @@ export interface BtcInfo {
   warnings: string;
 }
 
+export interface BtcTransactionStatus {
+  confirmed: boolean;
+  block_height?: number | null;
+}
+
 async function btcCmd(cmd: Cmd, tag: string, content?: any) {
   return await send_cmd("Bitcoind", { cmd, content }, tag);
 }
@@ -35,3 +40,6 @@ export async function get_balance(tag: string) {
   return await btcCmd("GetBalance", tag);
 }
 
+export async function get_transaction_status(tag: string, txid: string) {
+  return await btcCmd("GetTransactionStatus", tag, { txid });
+}

--- a/app/src/api/cmd.ts
+++ b/app/src/api/cmd.ts
@@ -31,6 +31,7 @@ export type Cmd =
   | "GetInfo"
   | "GetContainerLogs"
   | "TestMine"
+  | "GetTransactionStatus"
   | "ListChannels"
   | "AddPeer"
   | "ListPeers"

--- a/app/src/api/lnd.ts
+++ b/app/src/api/lnd.ts
@@ -33,6 +33,7 @@ export interface LndChannel {
   close_address?: string;
   push_amount_sat?: number;
   thaw_height?: number;
+  confirmation?: number;
 }
 
 export interface LndPeer {

--- a/app/src/helpers/bitcoin.ts
+++ b/app/src/helpers/bitcoin.ts
@@ -1,15 +1,44 @@
-export async function getTransactionStatus(txid) {
-  const res = await fetch(
-    `https://mempool.space/testnet/api/tx/${txid}/status`
-  );
+import * as btcApi from "../api/btc";
+import type { BtcTransactionStatus } from "../api/btc";
+
+interface ChainLookupOptions {
+  network?: string;
+  bitcoindTag?: string;
+}
+
+function getMempoolBaseUrl(network?: string) {
+  if (network === "bitcoin") {
+    return "https://mempool.space/api";
+  }
+  return "https://mempool.space/testnet/api";
+}
+
+export async function getTransactionStatus(
+  txid: string,
+  options: ChainLookupOptions = {}
+): Promise<BtcTransactionStatus> {
+  if (options.network === "regtest") {
+    if (!options.bitcoindTag) {
+      return { confirmed: false, block_height: null };
+    }
+    return await btcApi.get_transaction_status(options.bitcoindTag, txid);
+  }
+
+  const res = await fetch(`${getMempoolBaseUrl(options.network)}/tx/${txid}/status`);
   const status = await res.json();
   return status;
 }
 
-export async function getBlockTip() {
-  const res = await fetch(
-    `https://mempool.space/testnet/api/blocks/tip/height`
-  );
+export async function getBlockTip(options: ChainLookupOptions = {}) {
+  if (options.network === "regtest") {
+    if (!options.bitcoindTag) {
+      return 0;
+    }
+    const info = await btcApi.get_info(options.bitcoindTag);
+    return info?.blocks || 0;
+  }
+
+  const res = await fetch(`${getMempoolBaseUrl(options.network)}/blocks/tip/height`);
   const status = await res.json();
   return status;
 }

--- a/app/src/lnd/ChannelRows.svelte
+++ b/app/src/lnd/ChannelRows.svelte
@@ -10,7 +10,7 @@
   import ReceiveLine from "../components/ReceiveLine.svelte";
   import DotWrap from "../components/DotWrap.svelte";
   import Dot from "../components/Dot.svelte";
-  import { channels, lightningPeers, peers } from "../store";
+  import { channels, lightningPeers, peers, stack } from "../store";
   import { formatSatsNumbers } from "../helpers";
   import { getTransactionStatus, getBlockTip } from "../helpers/bitcoin";
   import Exit from "carbon-icons-svelte/lib/Exit.svelte";
@@ -27,11 +27,23 @@
   export let type = "";
   export let onclose = (id: string, dest: string) => {};
 
-  let channel_arr = $channels[tag];
+  let channel_arr = [];
+
+  $: channel_arr = $channels[tag] || [];
+  $: bitcoindTag = getBitcoindTag();
 
   $: peersObj = convertLightningPeersToObject($lightningPeers);
 
   $: peersConnectObj = convertPeersToConnectObj($peers[tag]);
+
+  function getBitcoindTag() {
+    const nodes = $stack?.nodes || [];
+    const lightningNode = nodes.find((node) => node.name === tag);
+    const linkedBitcoind = lightningNode?.links?.find((link) =>
+      nodes.some((node) => node.name === link && node.type === "Btc")
+    );
+    return linkedBitcoind || nodes.find((node) => node.type === "Btc")?.name;
+  }
 
   function copyText(txt: string) {
     navigator.clipboard.writeText(txt);
@@ -106,11 +118,12 @@
         return 0;
       }
       let tx_id = channel_point_arr[0];
-      const transaction_status = await getTransactionStatus(tx_id);
-      if (!transaction_status.confirmed) {
+      const lookupOptions = { network: $stack?.network, bitcoindTag };
+      const transaction_status = await getTransactionStatus(tx_id, lookupOptions);
+      if (!transaction_status.confirmed || transaction_status.block_height == null) {
         return 0;
       }
-      const currentBlockHeight = await getBlockTip();
+      const currentBlockHeight = await getBlockTip(lookupOptions);
       return currentBlockHeight - transaction_status.block_height + 1;
     } catch (e) {
       console.warn(e);
@@ -120,17 +133,24 @@
 
   async function getChannelsConfirmation() {
     let new_channel = [];
-    let notActiveExist = false;
+    let updated = false;
+
     for (const chan of channel_arr) {
       if (!chan.active) {
-        notActiveExist = true;
         const confirmation = await getConfirmation(chan);
         new_channel.push({ ...chan, confirmation });
+        updated = updated || chan.confirmation !== confirmation;
+      } else {
+        new_channel.push(chan);
       }
     }
-    // if (notActiveExist) {
-    //   channel_arr = [...new_channel];
-    // }
+
+    if (updated) {
+      channel_arr = [...new_channel];
+      channels.update((chans) => {
+        return { ...chans, [tag]: new_channel };
+      });
+    }
   }
 
   function openReconnectPeerModal(e, pubkey) {

--- a/app/src/lnd/Channels.svelte
+++ b/app/src/lnd/Channels.svelte
@@ -159,6 +159,18 @@
       const channelsData = await getLndPendingAndActiveChannels(tag);
       newChannels = channelsData;
     }
+
+    const existingByChannelPoint = new Map(
+      ($channels[tag] || []).map((channel) => [channel.channel_point, channel])
+    );
+    newChannels = newChannels.map((channel) => {
+      const existing = existingByChannelPoint.get(channel.channel_point);
+      if (!channel.active && existing?.confirmation != null) {
+        return { ...channel, confirmation: existing.confirmation };
+      }
+      return channel;
+    });
+
     if (JSON.stringify(newChannels) !== JSON.stringify($channels[tag])) {
       channels.update((chans) => {
         return { ...chans, [tag]: newChannels };

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -284,6 +284,11 @@ pub struct TestMine {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetTransactionStatus {
+    pub txid: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AddPeer {
     pub pubkey: String,
     pub host: String,
@@ -350,6 +355,7 @@ pub enum BitcoindCmd {
     GetInfo,
     TestMine(TestMine),
     GetBalance,
+    GetTransactionStatus(GetTransactionStatus),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/conn/bitcoin/bitcoinrpc.rs
+++ b/src/conn/bitcoin/bitcoinrpc.rs
@@ -2,12 +2,19 @@ extern crate bitcoincore_rpc;
 
 use crate::images::btc::BtcImage;
 use anyhow::Result;
-use bitcoincore_rpc::bitcoin::{Address, BlockHash};
+use bitcoincore_rpc::bitcoin::{Address, BlockHash, Txid};
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 use bitcoincore_rpc_json::{AddressType, GetBlockchainInfoResult};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 pub struct BitcoinRPC(Client);
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TransactionStatus {
+    pub confirmed: bool,
+    pub block_height: Option<u64>,
+}
 
 impl BitcoinRPC {
     pub fn new(btc: &BtcImage, url: &str, port: &str) -> Result<Self> {
@@ -52,6 +59,24 @@ impl BitcoinRPC {
 
     pub fn get_wallet_balance(&self) -> Result<f64> {
         Ok(self.0.get_balance(Some(6), None)?.as_btc())
+    }
+
+    pub fn get_transaction_status(&self, txid: String) -> Result<TransactionStatus> {
+        let txid = Txid::from_str(&txid)?;
+        let tx = self.0.get_raw_transaction_info(&txid, None)?;
+
+        let Some(block_hash) = tx.blockhash else {
+            return Ok(TransactionStatus {
+                confirmed: false,
+                block_height: None,
+            });
+        };
+
+        let header = self.0.get_block_header_info(&block_hash)?;
+        Ok(TransactionStatus {
+            confirmed: tx.confirmations.unwrap_or(0) > 0,
+            block_height: Some(header.height as u64),
+        })
     }
 
     pub fn test_mine(&self, n: u64, addr: Option<String>) -> Result<Vec<BlockHash>> {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -714,6 +714,10 @@ pub async fn handle(
                     let res = client.get_wallet_balance()?;
                     Some(serde_json::to_string(&res)?)
                 }
+                BitcoindCmd::GetTransactionStatus(tx) => {
+                    let res = client.get_transaction_status(tx.txid)?;
+                    Some(serde_json::to_string(&res)?)
+                }
             }
         }
         Cmd::Lnd(c) => {


### PR DESCRIPTION
Fixes #182.

## Summary
- use the local Bitcoind RPC for regtest channel funding transaction status instead of the hard-coded testnet mempool.space endpoint
- choose the mainnet mempool.space endpoint when the stack network is bitcoin, while keeping testnet as the fallback
- persist computed inactive channel confirmations and preserve them across channel polling refreshes

## Verification
- npm_config_cache=/private/tmp/npm-cache-swarm npm ci
- npm run build
- npm run check (fails on existing repo-wide type errors such as app/src/api/swarm.ts Cmd union entries and EventTarget.value usages)
- CARGO_HOME=/private/tmp/cargo-home-swarm CARGO_TARGET_DIR=/private/tmp/sphinx-swarm-target PROTOC=/private/tmp/protoc-local/bin/protoc cargo check
- git diff --check -- app/src/api/btc.ts app/src/api/cmd.ts app/src/api/lnd.ts app/src/helpers/bitcoin.ts app/src/lnd/ChannelRows.svelte app/src/lnd/Channels.svelte src/cmd.rs src/conn/bitcoin/bitcoinrpc.rs src/handler.rs