### PR TITLE
[codex] Use local regtest tx status for channel confirmations

### DIFF
--- a/app/src/api/btc.ts
+++ b/app/src/api/btc.ts
@@ -35,3 +35,6 @@ export async function get_balance(tag: string) {
   return await btcCmd("GetBalance", tag);
 }
 
+export async function get_transaction_status(tag: string, txid: string) {
+  return await btcCmd("GetTransactionStatus", tag, { txid });
+}

--- a/app/src/api/cmd.ts
+++ b/app/src/api/cmd.ts
@@ -29,6 +29,7 @@ export type Cmd =
   | "ListUsers"
   | "AddUser"
   | "GetInfo"
+  | "GetTransactionStatus"
   | "GetContainerLogs"
   | "TestMine"
   | "ListChannels"

--- a/app/src/api/lnd.ts
+++ b/app/src/api/lnd.ts
@@ -33,6 +33,7 @@ export interface LndChannel {
   close_address?: string;
   push_amount_sat?: number;
   thaw_height?: number;
+  confirmation?: number;
 }
 
 export interface LndPeer {

--- a/app/src/helpers/bitcoin.ts
+++ b/app/src/helpers/bitcoin.ts
@@ -1,15 +1,36 @@
-export async function getTransactionStatus(txid) {
+import * as BTC from "../api/btc";
+
+type BitcoinNetwork = "bitcoin" | "regtest";
+
+function mempoolApiBase(network: BitcoinNetwork) {
+  return network === "bitcoin"
+    ? "https://mempool.space/api"
+    : "https://mempool.space/testnet/api";
+}
+
+export async function getTransactionStatus(
+  txid: string,
+  network: BitcoinNetwork,
+  btcTag: string
+) {
+  if (network === "regtest") {
+    return await BTC.get_transaction_status(btcTag, txid);
+  }
+
   const res = await fetch(
-    `https://mempool.space/testnet/api/tx/${txid}/status`
+    `${mempoolApiBase(network)}/tx/${txid}/status`
   );
   const status = await res.json();
   return status;
 }
 
-export async function getBlockTip() {
-  const res = await fetch(
-    `https://mempool.space/testnet/api/blocks/tip/height`
-  );
+export async function getBlockTip(network: BitcoinNetwork, btcTag: string) {
+  if (network === "regtest") {
+    const info = await BTC.get_info(btcTag);
+    return info.blocks;
+  }
+
+  const res = await fetch(`${mempoolApiBase(network)}/blocks/tip/height`);
   const status = await res.json();
   return status;
 }

--- a/app/src/lnd/ChannelRows.svelte
+++ b/app/src/lnd/ChannelRows.svelte
@@ -27,11 +27,24 @@
   export let type = "";
   export let onclose = (id: string, dest: string) => {};
 
-  let channel_arr = $channels[tag];
+  let channel_arr = $channels[tag] || [];
 
-  $: btcTag =
-    $stack.nodes.find((node) => node.type === "Btc" && node.place === "Internal")
-      ?.name || "bitcoind";
+  $: channel_arr = $channels[tag] || [];
+  $: btcTag = getBitcoinTag();
+
+  function getBitcoinTag() {
+    const nodes = $stack.nodes || [];
+    const lightningNode = nodes.find((node) => node.name === tag);
+    const linkedBitcoin = lightningNode?.links?.find((link) =>
+      nodes.some((node) => node.name === link && node.type === "Btc")
+    );
+    return (
+      linkedBitcoin ||
+      nodes.find((node) => node.type === "Btc" && node.place === "Internal")
+        ?.name ||
+      "bitcoind"
+    );
+  }
 
   $: peersObj = convertLightningPeersToObject($lightningPeers);
 
@@ -119,7 +132,7 @@
         return 0;
       }
       const currentBlockHeight = await getBlockTip($stack.network, btcTag);
-      return transaction_status.block_height
+      return transaction_status.block_height != null
         ? currentBlockHeight - transaction_status.block_height + 1
         : transaction_status.confirmations || 0;
     } catch (e) {
@@ -130,17 +143,23 @@
 
   async function getChannelsConfirmation() {
     let new_channel = [];
-    let notActiveExist = false;
+    let updated = false;
+
     for (const chan of channel_arr) {
       if (!chan.active) {
-        notActiveExist = true;
         const confirmation = await getConfirmation(chan);
         new_channel.push({ ...chan, confirmation });
+        updated = updated || chan.confirmation !== confirmation;
+      } else {
+        new_channel.push(chan);
       }
     }
-    // if (notActiveExist) {
-    //   channel_arr = [...new_channel];
-    // }
+
+    if (updated) {
+      channels.update((chans) => {
+        return { ...chans, [tag]: new_channel };
+      });
+    }
   }
 
   function openReconnectPeerModal(e, pubkey) {

--- a/app/src/lnd/ChannelRows.svelte
+++ b/app/src/lnd/ChannelRows.svelte
@@ -10,7 +10,7 @@
   import ReceiveLine from "../components/ReceiveLine.svelte";
   import DotWrap from "../components/DotWrap.svelte";
   import Dot from "../components/Dot.svelte";
-  import { channels, lightningPeers, peers } from "../store";
+  import { channels, lightningPeers, peers, stack } from "../store";
   import { formatSatsNumbers } from "../helpers";
   import { getTransactionStatus, getBlockTip } from "../helpers/bitcoin";
   import Exit from "carbon-icons-svelte/lib/Exit.svelte";
@@ -28,6 +28,10 @@
   export let onclose = (id: string, dest: string) => {};
 
   let channel_arr = $channels[tag];
+
+  $: btcTag =
+    $stack.nodes.find((node) => node.type === "Btc" && node.place === "Internal")
+      ?.name || "bitcoind";
 
   $: peersObj = convertLightningPeersToObject($lightningPeers);
 
@@ -106,12 +110,18 @@
         return 0;
       }
       let tx_id = channel_point_arr[0];
-      const transaction_status = await getTransactionStatus(tx_id);
+      const transaction_status = await getTransactionStatus(
+        tx_id,
+        $stack.network,
+        btcTag
+      );
       if (!transaction_status.confirmed) {
         return 0;
       }
-      const currentBlockHeight = await getBlockTip();
-      return currentBlockHeight - transaction_status.block_height + 1;
+      const currentBlockHeight = await getBlockTip($stack.network, btcTag);
+      return transaction_status.block_height
+        ? currentBlockHeight - transaction_status.block_height + 1
+        : transaction_status.confirmations || 0;
     } catch (e) {
       console.warn(e);
       return 0;

--- a/app/src/lnd/Channels.svelte
+++ b/app/src/lnd/Channels.svelte
@@ -150,8 +150,25 @@
     }
   }
 
+  function keepChannelConfirmations(newChannels: LND.LndChannel[]) {
+    const confirmationsByPoint = new Map(
+      ($channels[tag] || []).map((channel) => [
+        channel.channel_point,
+        channel.confirmation,
+      ])
+    );
+
+    return newChannels.map((channel) => {
+      const confirmation = confirmationsByPoint.get(channel.channel_point);
+      if (!channel.active && confirmation != null) {
+        return { ...channel, confirmation };
+      }
+      return channel;
+    });
+  }
+
   async function getChannels() {
-    let newChannels = [];
+    let newChannels: LND.LndChannel[] = [];
     if (type === "Cln") {
       const peersData = await CLN.list_peer_channels(tag);
       newChannels = await parseClnListPeerChannelsRes(peersData);
@@ -159,6 +176,7 @@
       const channelsData = await getLndPendingAndActiveChannels(tag);
       newChannels = channelsData;
     }
+    newChannels = keepChannelConfirmations(newChannels);
     if (JSON.stringify(newChannels) !== JSON.stringify($channels[tag])) {
       channels.update((chans) => {
         return { ...chans, [tag]: newChannels };

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -345,11 +345,17 @@ pub struct GetInvoice {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetTransactionStatus {
+    pub txid: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "cmd", content = "content")]
 pub enum BitcoindCmd {
     GetInfo,
     TestMine(TestMine),
     GetBalance,
+    GetTransactionStatus(GetTransactionStatus),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/conn/bitcoin/bitcoinrpc.rs
+++ b/src/conn/bitcoin/bitcoinrpc.rs
@@ -2,12 +2,20 @@ extern crate bitcoincore_rpc;
 
 use crate::images::btc::BtcImage;
 use anyhow::Result;
-use bitcoincore_rpc::bitcoin::{Address, BlockHash};
+use bitcoincore_rpc::bitcoin::{Address, BlockHash, Txid};
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 use bitcoincore_rpc_json::{AddressType, GetBlockchainInfoResult};
+use serde::Serialize;
 use std::str::FromStr;
 
 pub struct BitcoinRPC(Client);
+
+#[derive(Serialize)]
+pub struct TransactionStatus {
+    pub confirmed: bool,
+    pub block_height: Option<u32>,
+    pub confirmations: u32,
+}
 
 impl BitcoinRPC {
     pub fn new(btc: &BtcImage, url: &str, port: &str) -> Result<Self> {
@@ -30,6 +38,26 @@ impl BitcoinRPC {
 
     pub fn get_info(&self) -> Result<GetBlockchainInfoResult> {
         Ok(self.0.get_blockchain_info()?)
+    }
+
+    pub fn get_transaction_status(&self, txid: String) -> Result<TransactionStatus> {
+        let txid = Txid::from_str(&txid)?;
+        let transaction = self.0.get_raw_transaction_info(&txid, None)?;
+        let confirmations = transaction.confirmations.unwrap_or(0);
+        let block_height = transaction
+            .blockhash
+            .map(|block_hash| {
+                self.0
+                    .get_block_header_info(&block_hash)
+                    .map(|b| b.height as u32)
+            })
+            .transpose()?;
+
+        Ok(TransactionStatus {
+            confirmed: confirmations > 0,
+            block_height,
+            confirmations,
+        })
     }
 
     pub fn create_or_load_wallet(&self) -> Result<()> {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -714,6 +714,10 @@ pub async fn handle(
                     let res = client.get_wallet_balance()?;
                     Some(serde_json::to_string(&res)?)
                 }
+                BitcoindCmd::GetTransactionStatus(ts) => {
+                    let res = client.get_transaction_status(ts.txid)?;
+                    Some(serde_json::to_string(&res)?)
+                }
             }
         }
         Cmd::Lnd(c) => {


### PR DESCRIPTION
Fixes #182.

This fixes the CLN channel confirmation display when the stack runs on regtest. The channel UI was asking mempool.space for the funding transaction, which does not work for local regtest channel funding transactions.

Changes:
- add a Bitcoind `GetTransactionStatus` command backed by local bitcoind RPC
- return confirmed state, block height, and confirmation count from `getrawtransaction` plus block header lookup
- have the frontend use local bitcoind for regtest channel confirmation checks
- keep mempool.space lookup for non-regtest stacks

Validation:
- `cargo check`
- `cargo test --lib` (21 passed)
- `npm run build`
- `git diff --check`
- `rustfmt --edition 2021 --check src/conn/bitcoin/bitcoinrpc.rs src/cmd.rs`

Note: `npm run check` still fails on existing unrelated repo-wide Svelte/TypeScript diagnostics in files such as `api/swarm.ts`, `Flow.svelte`, `Boltwall.svelte`, `Jarvis.svelte`, `NodeVersionupdater.svelte`, and `NodeStats.svelte`; I did not touch those paths. Repo-wide `cargo fmt --check` also reports pre-existing formatting drift outside the touched Rust files, so I validated the touched Rust files directly.

Bounty note: this PR is intended for the Sphinx 350,000 sat bounty attached to issue #182. BTC payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`.
