### PR TITLE
Allow GetEnv for Super role on child swarms (fixes LLM key coverage reads)

### DIFF
--- a/src/bin/super/service/child_swarm/get_llm_keys.rs
+++ b/src/bin/super/service/child_swarm/get_llm_keys.rs
@@ -60,6 +60,8 @@ async fn handle_get_child_swarm_llm_keys(
         _ => LLM_KEY_NODES.iter().map(|n| n.to_string()).collect(),
     };
 
+    let mut last_err: Option<String> = None;
+
     for node in &nodes {
         let cmd = Cmd::Swarm(SwarmCmd::GetEnv(node.clone()));
         let res = match tokio::time::timeout(
@@ -69,13 +71,32 @@ async fn handle_get_child_swarm_llm_keys(
         .await
         {
             Ok(Ok(res)) => res,
-            _ => continue,
+            Ok(Err(err)) => {
+                last_err = Some(err.to_string());
+                continue;
+            }
+            Err(_) => {
+                last_err = Some(format!("timed out reading env from {}", node));
+                continue;
+            }
         };
-        let result: SwarmResponse = match res.json().await {
+        let status = res.status();
+        let body = res.text().await.unwrap_or_default();
+        if status != 200 {
+            let snippet: String = body.chars().take(120).collect();
+            last_err = Some(format!("{} from child swarm: {}", status, snippet));
+            continue;
+        }
+        let result: SwarmResponse = match serde_json::from_str(&body) {
             Ok(res_body) => res_body,
-            Err(_) => continue,
+            Err(_) => {
+                let snippet: String = body.chars().take(120).collect();
+                last_err = Some(format!("unexpected response from child swarm: {}", snippet));
+                continue;
+            }
         };
         if !result.success {
+            last_err = Some(result.message);
             continue;
         }
         let envs: HashMap<String, String> = match result.data {
@@ -99,7 +120,8 @@ async fn handle_get_child_swarm_llm_keys(
         });
     }
 
-    Err(anyhow!(
+    Err(anyhow!(last_err.unwrap_or_else(|| {
         "no LLM-consuming container (bifrost/repo2graph) running — keys can't be verified remotely"
-    ))
+            .to_string()
+    })))
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -70,6 +70,7 @@ fn access(cmd: &Cmd, stack: &Stack, user_id: &Option<u32>) -> bool {
                 SwarmCmd::GetApiToken => true,
                 SwarmCmd::ChangeReservedSwarmToActive(_) => true,
                 SwarmCmd::UpdateEvn(_) => true,
+                SwarmCmd::GetEnv(_) => true,
                 SwarmCmd::UpdateNeo4jConfig(_) => true,
                 _ => false,
             },


### PR DESCRIPTION
## What

Follow-up to #722. Fleet coverage / "Show LLM keys" reads were failing on real swarms with a misleading "no LLM-consuming container (bifrost/repo2graph) running" error.

**Root cause** (verified live against a production swarm): the child swarm's `access()` allowlist for `Role::Super` — the user the superadmin logs in as — permits `UpdateEvn` but not `GetEnv`. Every read came back `access denied` (confirmed in the child's logs: `handle ERR access denied` ×2, one per fallback container), and the lookup loop swallowed it as if the containers didn't exist.

## Changes

- **child** (`src/handler.rs`): allowlist `SwarmCmd::GetEnv` for `Role::Super`. Read-only command, same trust level as the already-allowed `UpdateEvn`
- **superadmin** (`get_llm_keys.rs`): track the actual failure per container attempt (HTTP status + body snippet, access denied, timeout, bad body) and return that instead of the generic no-container message, so the coverage table shows the real reason

## Deploy note

The child-side line means **swarms need an updated stack image** before coverage reads work (until then they now show the honest `access denied` error instead of the misleading one). Rotation/distribution from #722 is unaffected and already works — `UpdateEvn` was always allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)