### PR TITLE
Add hermes image with swarm-brokered OAuth login

### DIFF
--- a/app/src/nodes.ts
+++ b/app/src/nodes.ts
@@ -55,6 +55,7 @@ export type NodeType =
   | "Cln"
   | "Llama"
   | "Repo2Graph"
+  | "Hermes"
   | "Stakgraph"
   | "Bot";
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -254,6 +254,16 @@ pub enum SwarmCmd {
     ChangeReservedSwarmToActive(AssignSwarmNewDetails),
     UpdateSslCert,
     UpdateNeo4jConfig(UpdateNeo4jConfigRequest),
+    HermesAuthStart(HermesAuthRequest),
+    HermesAuthStatus(String),
+    HermesAuthList(HermesAuthRequest),
+    HermesAuthLogout(HermesAuthRequest),
+}
+
+/// `provider` defaults to "xai-oauth" when omitted.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HermesAuthRequest {
+    pub provider: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -345,6 +345,7 @@ pub fn migrate_stack(stack: &mut Stack) {
     use crate::defaults::env_is_true;
     use crate::images::bifrost::BifrostImage;
     use crate::images::graphmindset::GraphMindsetImage;
+    use crate::images::hermes::HermesImage;
     use crate::images::hive_relay::HiveRelayImage;
     use crate::images::quickwit::QuickwitImage;
     use crate::images::vector::VectorImage;
@@ -359,6 +360,7 @@ pub fn migrate_stack(stack: &mut Stack) {
     let has_vector = stack.nodes.iter().any(|n| n.name() == "vector");
     let has_hive_relay = stack.nodes.iter().any(|n| n.name() == "hive-relay");
     let has_bifrost = stack.nodes.iter().any(|n| n.name() == "bifrost");
+    let has_hermes = stack.nodes.iter().any(|n| n.name() == "hermes");
     let has_graphmindset = stack.nodes.iter().any(|n| n.name() == "graphmindset");
 
     log::info!("=> migrating stack: ensuring second-brain nodes and links");
@@ -412,6 +414,14 @@ pub fn migrate_stack(stack: &mut Stack) {
         log::info!("=> added bifrost node");
     }
 
+    if !has_hermes {
+        // Subscription proxy for OAuth-backed LLM providers. No links: it
+        // talks only to the provider, and repo2graph reaches it by hostname.
+        let hermes = HermesImage::new("hermes", "latest", "8645");
+        stack.nodes.push(Node::Internal(Image::Hermes(hermes)));
+        log::info!("=> added hermes node");
+    }
+
     // Update existing Repo2Graph and Stakgraph links to include bifrost
     for node in &mut stack.nodes {
         match node {
@@ -422,6 +432,10 @@ pub fn migrate_stack(stack: &mut Stack) {
                 if !img.links.contains(&"jarvis".to_string()) {
                     img.links.push("jarvis".to_string());
                     log::info!("=> added jarvis link to repo2graph");
+                }
+                if !img.links.contains(&"hermes".to_string()) {
+                    img.links.push("hermes".to_string());
+                    log::info!("=> added hermes link to repo2graph");
                 }
             }
             Node::Internal(Image::Stakgraph(ref mut img)) => {
@@ -533,6 +547,7 @@ impl Stack {
                 Image::Vector(v) => Node::Internal(Image::Vector(v)),
                 Image::HiveRelay(h) => Node::Internal(Image::HiveRelay(h)),
                 Image::Bifrost(b) => Node::Internal(Image::Bifrost(b)),
+                Image::Hermes(h) => Node::Internal(Image::Hermes(h)),
             },
         });
         Stack {

--- a/src/dock.rs
+++ b/src/dock.rs
@@ -516,6 +516,33 @@ pub async fn exec(docker: &Docker, id: &str, cmd: &str) -> Result<String> {
     Ok(ret.join("/n"))
 }
 
+/// Like `exec` but takes a pre-split argv instead of a space-delimited string,
+/// and returns the output verbatim. For commands whose arguments can't be
+/// assumed space-free, or whose output is meant to be read rather than logged.
+pub async fn exec_no_tty(docker: &Docker, id: &str, cmd: Vec<String>) -> Result<String> {
+    let exec = docker
+        .create_exec(
+            id,
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                tty: Some(false),
+                cmd: Some(cmd),
+                ..Default::default()
+            },
+        )
+        .await?
+        .id;
+    let started = docker.start_exec(&exec, None).await?;
+    let mut ret = String::new();
+    if let StartExecResults::Attached { mut output, .. } = started {
+        while let Some(Ok(msg)) = output.next().await {
+            ret.push_str(&msg.to_string());
+        }
+    }
+    Ok(ret)
+}
+
 pub async fn sleep(millis: u64) {
     tokio::time::sleep(tokio::time::Duration::from_millis(millis)).await;
 }

--- a/src/graphmindset.rs
+++ b/src/graphmindset.rs
@@ -2,6 +2,7 @@ use crate::config::*;
 use crate::defaults::*;
 use crate::images::boltwall::BoltwallImage;
 use crate::images::bot::BotImage;
+use crate::images::hermes::HermesImage;
 use crate::images::jarvis::JarvisImage;
 use crate::images::graphmindset::GraphMindsetImage;
 use crate::images::navfiber::NavFiberImage;
@@ -84,11 +85,15 @@ pub fn graph_mindset_imgs(_network: &str, host: Option<String>) -> Vec<Image> {
     gm.links(vec!["jarvis"]);
     gm.host(host.clone());
 
+    // hermes (subscription proxy for OAuth-backed LLM providers)
+    v = "latest";
+    let hermes = HermesImage::new("hermes", v, "8645");
+
     // repo2graph
     v = "latest";
     let mut repo2graph = Repo2GraphImage::new("repo2graph", v, "3355");
     repo2graph.host(host.clone());
-    repo2graph.links(vec!["neo4j", "boltwall", "jarvis"]);
+    repo2graph.links(vec!["neo4j", "boltwall", "jarvis", "hermes"]);
 
     // stakgraph
     v = "latest";
@@ -105,6 +110,7 @@ pub fn graph_mindset_imgs(_network: &str, host: Option<String>) -> Vec<Image> {
         Image::Jarvis(jarvis),
         Image::Redis(redis),
         Image::Repo2Graph(repo2graph),
+        Image::Hermes(hermes),
         Image::Stakgraph(stakgraph),
     ]
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -22,6 +22,7 @@ use crate::conn::swarm::{
 };
 use crate::conn::swarm::{create_bot_invoice, get_bot_balance, get_bot_payments, get_bot_token, get_neo4j_password};
 use crate::dock::*;
+use crate::hermes_auth;
 use crate::dock::restart_node_container_global;
 use crate::images::DockerHubImage;
 use crate::images::Image;
@@ -129,6 +130,32 @@ pub async fn handle(
                 log::info!("RestartContainer -> {}", id);
                 restart_node_container_global(docker, &id, proj).await?;
                 Some(serde_json::to_string("{}")?)
+            }
+            // Hermes `auth add` is a device-code flow: it prints a
+            // verification URL within a second, then polls the provider for
+            // minutes waiting for a human to approve in a browser. Too long
+            // to hold the request open, so it's start-then-poll.
+            SwarmCmd::HermesAuthStart(req) => {
+                let provider = hermes_auth::provider_or_default(&req.provider)?;
+                log::info!("HermesAuthStart -> {}", &provider);
+                let session = hermes_auth::start(docker, &provider).await?;
+                Some(serde_json::to_string(&session)?)
+            }
+            SwarmCmd::HermesAuthStatus(session_id) => {
+                let session = hermes_auth::status(&session_id).await?;
+                Some(serde_json::to_string(&session)?)
+            }
+            SwarmCmd::HermesAuthList(req) => {
+                let provider = hermes_auth::provider_or_default(&req.provider)?;
+                log::info!("HermesAuthList -> {}", &provider);
+                let out = hermes_auth::list(docker, &provider).await?;
+                Some(serde_json::to_string(&out)?)
+            }
+            SwarmCmd::HermesAuthLogout(req) => {
+                let provider = hermes_auth::provider_or_default(&req.provider)?;
+                log::info!("HermesAuthLogout -> {}", &provider);
+                let out = hermes_auth::logout(docker, &provider).await?;
+                Some(serde_json::to_string(&out)?)
             }
             SwarmCmd::AddNode(node) => {
                 log::info!("AddNode -> {:?}", node);

--- a/src/hermes_auth.rs
+++ b/src/hermes_auth.rs
@@ -1,0 +1,242 @@
+//! Drives `hermes auth ...` inside the hermes container on behalf of callers
+//! that can't reach the docker socket themselves (repo2graph, an external UI).
+//!
+//! `hermes auth add xai-oauth --no-browser` is a device-code flow: it prints a
+//! verification URL plus a user code within the first second, then polls the
+//! provider — for minutes — until someone approves the login in a browser. No
+//! stdin, no TTY needed, but far too long to hold an HTTP request open. So
+//! `start()` kicks the exec off, returns as soon as the URL is on the wire,
+//! and `status()` is polled for the rest.
+
+use crate::dock::exec_no_tty;
+use crate::images::hermes::HERMES_BIN;
+use crate::secrets;
+use crate::utils::domain;
+use anyhow::{anyhow, Result};
+use bollard::exec::{CreateExecOptions, StartExecResults};
+use bollard::Docker;
+use futures_util::StreamExt;
+use once_cell::sync::Lazy;
+use rocket::tokio;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Container to exec into. Matches the node name used by the presets.
+const HERMES_NODE: &str = "hermes";
+
+pub const DEFAULT_PROVIDER: &str = "xai-oauth";
+
+/// How long `start()` waits for the verification URL before replying anyway.
+const FIRST_OUTPUT_TIMEOUT_MS: u64 = 8_000;
+const POLL_INTERVAL_MS: u64 = 200;
+
+/// Login output is a handful of lines; anything past this is a runaway CLI.
+const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+
+/// Finished sessions are only kept so a late poll can still read the result.
+const MAX_SESSIONS: usize = 20;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AuthSession {
+    pub session_id: String,
+    pub provider: String,
+    /// Everything the CLI has printed so far — the verification URL and user
+    /// code live in here.
+    pub output: String,
+    pub done: bool,
+    pub exit_code: Option<i64>,
+}
+
+static SESSIONS: Lazy<Mutex<HashMap<String, Arc<Mutex<AuthSession>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Providers are interpolated into an exec argv. That's not a shell, so
+/// there's no quoting hazard, but an unchecked value could still smuggle in
+/// flags (`--config`, `--help`) and make the CLI do something else entirely.
+fn validate_provider(provider: &str) -> Result<String> {
+    if provider.is_empty() || provider.len() > 64 {
+        return Err(anyhow!("invalid hermes provider"));
+    }
+    // A leading dash would make the CLI read it as a flag, not a provider.
+    if provider.starts_with('-') {
+        return Err(anyhow!("invalid hermes provider (cannot start with '-')"));
+    }
+    if !provider
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(anyhow!(
+            "invalid hermes provider (expected lowercase, digits and dashes)"
+        ));
+    }
+    Ok(provider.to_string())
+}
+
+pub fn provider_or_default(provider: &Option<String>) -> Result<String> {
+    match provider {
+        Some(p) => validate_provider(p),
+        None => Ok(DEFAULT_PROVIDER.to_string()),
+    }
+}
+
+/// `hermes auth add <provider> --no-browser`, backgrounded.
+pub async fn start(docker: &Docker, provider: &str) -> Result<AuthSession> {
+    let provider = validate_provider(provider)?;
+    let container = domain(HERMES_NODE);
+
+    let cmd = vec![
+        HERMES_BIN.to_string(),
+        "auth".to_string(),
+        "add".to_string(),
+        provider.clone(),
+        "--no-browser".to_string(),
+    ];
+
+    let exec_id = docker
+        .create_exec(
+            &container,
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                // No TTY: keeps the CLI from emitting ANSI escapes and
+                // spinner redraws, so the URL comes back as plain text.
+                tty: Some(false),
+                cmd: Some(cmd),
+                ..Default::default()
+            },
+        )
+        .await?
+        .id;
+
+    let started = docker.start_exec(&exec_id, None).await?;
+    let mut output = match started {
+        StartExecResults::Attached { output, .. } => output,
+        StartExecResults::Detached => return Err(anyhow!("hermes auth exec detached")),
+    };
+
+    let session_id = secrets::random_word(12);
+    let session = Arc::new(Mutex::new(AuthSession {
+        session_id: session_id.clone(),
+        provider,
+        output: String::new(),
+        done: false,
+        exit_code: None,
+    }));
+
+    {
+        let mut sessions = SESSIONS.lock().await;
+        prune(&mut sessions).await;
+        sessions.insert(session_id.clone(), session.clone());
+    }
+
+    let drain_into = session.clone();
+    let docker = docker.clone();
+    let exec_id_for_task = exec_id.clone();
+    tokio::spawn(async move {
+        while let Some(Ok(msg)) = output.next().await {
+            let mut s = drain_into.lock().await;
+            if s.output.len() < MAX_OUTPUT_BYTES {
+                s.output.push_str(&msg.to_string());
+            }
+        }
+        let exit_code = docker
+            .inspect_exec(&exec_id_for_task)
+            .await
+            .ok()
+            .and_then(|i| i.exit_code);
+        let mut s = drain_into.lock().await;
+        s.exit_code = exit_code;
+        s.done = true;
+    });
+
+    // Hold the caller just long enough for the verification URL to show up,
+    // so the common case is a single round trip.
+    let deadline = FIRST_OUTPUT_TIMEOUT_MS / POLL_INTERVAL_MS;
+    for _ in 0..deadline {
+        {
+            let s = session.lock().await;
+            if !s.output.trim().is_empty() || s.done {
+                return Ok(s.clone());
+            }
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
+    }
+
+    let snapshot = session.lock().await.clone();
+    Ok(snapshot)
+}
+
+pub async fn status(session_id: &str) -> Result<AuthSession> {
+    let session = {
+        let sessions = SESSIONS.lock().await;
+        sessions.get(session_id).cloned()
+    };
+    match session {
+        Some(s) => Ok(s.lock().await.clone()),
+        None => Err(anyhow!("unknown hermes auth session")),
+    }
+}
+
+/// `hermes auth list <provider>` — fast, exits on its own.
+pub async fn list(docker: &Docker, provider: &str) -> Result<String> {
+    let provider = validate_provider(provider)?;
+    run(docker, vec!["auth", "list", &provider]).await
+}
+
+/// `hermes auth logout <provider>` — drops every stored credential for it.
+pub async fn logout(docker: &Docker, provider: &str) -> Result<String> {
+    let provider = validate_provider(provider)?;
+    run(docker, vec!["auth", "logout", &provider]).await
+}
+
+async fn run(docker: &Docker, args: Vec<&str>) -> Result<String> {
+    let mut cmd = vec![HERMES_BIN.to_string()];
+    cmd.extend(args.into_iter().map(|a| a.to_string()));
+    exec_no_tty(docker, &domain(HERMES_NODE), cmd).await
+}
+
+/// Keep the map from growing without bound. In-flight logins are never
+/// dropped; finished ones are, oldest-insertion-order first.
+async fn prune(sessions: &mut HashMap<String, Arc<Mutex<AuthSession>>>) {
+    if sessions.len() < MAX_SESSIONS {
+        return;
+    }
+    let mut finished = Vec::new();
+    for (id, s) in sessions.iter() {
+        if s.lock().await.done {
+            finished.push(id.clone());
+        }
+    }
+    for id in finished {
+        sessions.remove(&id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_validation_rejects_flag_smuggling() {
+        assert!(validate_provider("xai-oauth").is_ok());
+        assert!(validate_provider("anthropic-oauth").is_ok());
+
+        assert!(validate_provider("--help").is_err());
+        assert!(validate_provider("xai oauth").is_err());
+        assert!(validate_provider("xai/../etc").is_err());
+        assert!(validate_provider("XAI-OAUTH").is_err());
+        assert!(validate_provider("").is_err());
+    }
+
+    #[test]
+    fn test_provider_defaults_to_xai_oauth() {
+        assert_eq!(provider_or_default(&None).unwrap(), "xai-oauth");
+        assert_eq!(
+            provider_or_default(&Some("anthropic-oauth".to_string())).unwrap(),
+            "anthropic-oauth"
+        );
+        assert!(provider_or_default(&Some("--config".to_string())).is_err());
+    }
+}

--- a/src/images/hermes.rs
+++ b/src/images/hermes.rs
@@ -66,16 +66,37 @@
 //! nothing, since a login that was still pending is dead anyway; the stored
 //! credentials themselves are on the volume (see HERMES_HOME below).
 //!
+//! # There is no token to hand out
+//!
+//! A successful login does not yield a bearer token you can pass around. The
+//! OAuth credentials stay in auth.json on the volume and rotate transparently;
+//! `auth list` prints only metadata (provider, pool index, active/cooldown,
+//! expiry), never the raw access or refresh token. So `HermesAuthList` cannot
+//! leak a credential even though it returns CLI output verbatim.
+//!
+//! The proxy *is* the credential. A harness consumes it by using
+//! `http://hermes.sphinx:8645/v1` as an OpenAI-compatible base URL — clients
+//! send **any** bearer token, and the proxy attaches the real OAuth credential
+//! on the way upstream.
+//!
+//! That "any bearer token" is why this container publishes no host port and
+//! carries no traefik labels: anything that can reach the port can spend the
+//! subscription. Keep it on the sphinx-swarm network. If you ever do need it
+//! from outside, put real auth in front of it rather than publishing it.
+//!
 //! # Gotchas
 //!
 //!   - `hermes` is **not on PATH** for `docker exec`; the CLI lives in a venv.
 //!     Hence `HERMES_BIN` below.
 //!   - `HERMES_HOME` must point at the named volume or credentials are lost on
 //!     every image pull by the auto-updater. See the test at the bottom.
-//!   - No traefik labels, deliberately: the proxy is an unauthenticated
-//!     OpenAI-compatible endpoint sitting on top of your xAI session, so it
-//!     stays reachable only inside the sphinx-swarm network. repo2graph gets
-//!     `HERMES_URL=http://hermes.sphinx:8645` (see `repo2graph.rs`).
+//!   - `proxy start` defaults to `--provider nous`. We pass `--provider xai`
+//!     explicitly, or an xai-oauth login would authenticate fine and then
+//!     serve the wrong upstream. Note the auth namespace differs from the
+//!     proxy one: `xai-oauth` for `auth add`, `xai` for `proxy start`.
+//!   - Neither host-published nor traefik-fronted, deliberately — see above.
+//!     repo2graph reaches it at `HERMES_URL=http://hermes.sphinx:8645`
+//!     (see `repo2graph.rs`).
 //!   - Not in any preset's `auto_update` list. Those are all Sphinx/stakwork
 //!     images; auto-recreating a third-party `:latest` on every upstream push
 //!     is an opt-in decision, not a default.
@@ -112,6 +133,17 @@ pub struct HermesImage {
     pub version: String,
     pub port: String,
     pub links: Links,
+    /// Upstream the proxy forwards to. `proxy start` takes `<nous|xai>` and
+    /// **defaults to nous**, which is not what we want — a stack that logged
+    /// in with `auth add xai-oauth` but proxied to nous would authenticate
+    /// fine and then serve the wrong upstream. Note this namespace differs
+    /// from the auth provider's ("xai" here, "xai-oauth" there).
+    #[serde(default = "default_proxy_provider")]
+    pub provider: String,
+}
+
+fn default_proxy_provider() -> String {
+    "xai".to_string()
 }
 
 impl HermesImage {
@@ -121,6 +153,7 @@ impl HermesImage {
             version: version.to_string(),
             port: port.to_string(),
             links: vec![],
+            provider: default_proxy_provider(),
         }
     }
     pub fn links(&mut self, links: Vec<&str>) {
@@ -156,16 +189,20 @@ fn hermes(node: &HermesImage) -> Config<String> {
 
     let env = vec![format!("HERMES_HOME={}", HERMES_HOME)];
 
-    // No traefik labels: the proxy is an unauthenticated OpenAI-compatible
-    // endpoint sitting on top of your xAI session, so it stays reachable only
-    // inside the sphinx-swarm network (http://hermes.sphinx:PORT).
+    // The proxy accepts ANY bearer token — it attaches the real OAuth
+    // credential upstream itself, so anything that can reach this port can
+    // spend the subscription. Hence both: no traefik labels, and no host port
+    // publishing (the empty `ports` passed to host_config below). Reachable
+    // only from inside the sphinx-swarm network, at http://hermes.sphinx:PORT.
     Config {
         image: Some(format!("{}:{}", image, node.version)),
         hostname: Some(domain(&name)),
-        exposed_ports: exposed_ports(ports.clone()),
+        exposed_ports: exposed_ports(ports),
         cmd: Some(vec![
             "proxy".to_string(),
             "start".to_string(),
+            "--provider".to_string(),
+            node.provider.clone(),
             "--port".to_string(),
             node.port.clone(),
             "--host".to_string(),
@@ -175,7 +212,7 @@ fn hermes(node: &HermesImage) -> Config<String> {
         // Mirrors stdin_open/tty in the upstream compose example.
         open_stdin: Some(true),
         tty: Some(true),
-        host_config: host_config(&name, ports, root_vol, None, None),
+        host_config: host_config(&name, vec![], root_vol, None, None),
         ..Default::default()
     }
 }
@@ -185,16 +222,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_hermes_runs_the_proxy_on_its_port() {
+    fn test_hermes_runs_the_proxy_against_the_xai_upstream() {
         let img = HermesImage::new("hermes", "latest", "8645");
         let c = hermes(&img);
 
+        // --provider matters: `proxy start` defaults to nous, so without it
+        // an xai-oauth login would serve the wrong upstream.
         assert_eq!(
             c.cmd.unwrap(),
-            vec!["proxy", "start", "--port", "8645", "--host", "0.0.0.0"]
+            vec![
+                "proxy", "start", "--provider", "xai", "--port", "8645", "--host", "0.0.0.0"
+            ]
         );
         assert_eq!(c.image.unwrap(), "nousresearch/hermes-agent:latest");
         assert_eq!(c.hostname.unwrap(), "hermes.sphinx");
+    }
+
+    #[test]
+    fn test_hermes_port_is_not_published_to_the_host() {
+        let img = HermesImage::new("hermes", "latest", "8645");
+        let c = hermes(&img);
+
+        // The proxy takes any bearer token, so publishing it on the host would
+        // put a spendable xAI subscription on a public interface.
+        let bindings = c.host_config.unwrap().port_bindings.unwrap();
+        assert!(
+            bindings.is_empty(),
+            "hermes must not publish a host port, got: {:?}",
+            bindings
+        );
     }
 
     #[test]

--- a/src/images/hermes.rs
+++ b/src/images/hermes.rs
@@ -1,0 +1,219 @@
+//! Hermes Agent — the *subscription proxy*, which turns an OAuth-backed
+//! provider session (SuperGrok / X Premium+ via xAI OAuth) into a local
+//! OpenAI-compatible endpoint. Not the messaging gateway (`gateway run`,
+//! port 8642) — that's a separate service with Telegram/Discord/etc. attached.
+//!
+//! # Why auth goes through swarm
+//!
+//! Logging in means running `hermes auth add xai-oauth` *inside* this
+//! container. Neither repo2graph nor an external UI can do that themselves:
+//!
+//!   - `docker compose exec` cannot work at all. Swarm creates containers with
+//!     bollard directly (see `builder.rs`), not compose, so there is no compose
+//!     project to resolve against. The host-side equivalent would be
+//!     `docker exec -it hermes.sphinx ...`.
+//!   - Doing it from repo2graph would mean bind-mounting /var/run/docker.sock
+//!     into it plus shipping a docker CLI in the stakgraph-mcp image. The
+//!     socket is root-equivalent on the host and repo2graph runs LLM-directed
+//!     code over arbitrary cloned repos, so that trade isn't worth making.
+//!
+//! Swarm already holds the socket, so it brokers the exec instead. See
+//! `crate::hermes_auth` for the implementation.
+//!
+//! # Driving it over the API
+//!
+//! Four `SwarmCmd`s, all via the normal admin-JWT endpoint. There is no UI.
+//!
+//! Get a JWT (returns `{"token":"..."}`; port is 8000 in docker-compose.yml,
+//! 8800 in second-brain-2.yml):
+//!
+//! ```text
+//! JWT=$(curl -s -X POST http://localhost:8000/api/login \
+//!   -H 'Content-Type: application/json' \
+//!   -d '{"username":"admin","password":"password"}' | jq -r .token)
+//! ```
+//!
+//! Start a login. Returns `{session_id, provider, output, done, exit_code}`.
+//! `provider` is optional and defaults to `xai-oauth`:
+//!
+//! ```text
+//! curl -H "x-jwt: $JWT" --get http://localhost:8000/api/cmd \
+//!   --data-urlencode 'tag=SWARM' \
+//!   --data-urlencode 'txt={"type":"Swarm","data":{"cmd":"HermesAuthStart","content":{"provider":"xai-oauth"}}}'
+//! ```
+//!
+//! `auth add` is a *device-code* flow: it prints a verification URL and user
+//! code within about a second, then polls xAI for minutes until a human
+//! approves in a browser. No stdin and no TTY are involved, but it's far too
+//! slow to hold an HTTP request open — so `HermesAuthStart` blocks only until
+//! the URL is on the wire (8s cap) and backgrounds the rest. The URL and code
+//! are in the `output` field of the response.
+//!
+//! Poll until `done` is true. Note `content` here is a bare string, not an
+//! object:
+//!
+//! ```text
+//! curl -H "x-jwt: $JWT" --get http://localhost:8000/api/cmd \
+//!   --data-urlencode 'tag=SWARM' \
+//!   --data-urlencode 'txt={"type":"Swarm","data":{"cmd":"HermesAuthStatus","content":"<session_id>"}}'
+//! ```
+//!
+//! `HermesAuthList` and `HermesAuthLogout` take the same `{"provider":...}`
+//! content as `HermesAuthStart`, run synchronously, and return the CLI output
+//! as a string. Logout drops every stored credential for that provider.
+//!
+//! Sessions live in memory only — a swarm restart forgets them. That costs
+//! nothing, since a login that was still pending is dead anyway; the stored
+//! credentials themselves are on the volume (see HERMES_HOME below).
+//!
+//! # Gotchas
+//!
+//!   - `hermes` is **not on PATH** for `docker exec`; the CLI lives in a venv.
+//!     Hence `HERMES_BIN` below.
+//!   - `HERMES_HOME` must point at the named volume or credentials are lost on
+//!     every image pull by the auto-updater. See the test at the bottom.
+//!   - No traefik labels, deliberately: the proxy is an unauthenticated
+//!     OpenAI-compatible endpoint sitting on top of your xAI session, so it
+//!     stays reachable only inside the sphinx-swarm network. repo2graph gets
+//!     `HERMES_URL=http://hermes.sphinx:8645` (see `repo2graph.rs`).
+//!   - Not in any preset's `auto_update` list. Those are all Sphinx/stakwork
+//!     images; auto-recreating a third-party `:latest` on every upstream push
+//!     is an opt-in decision, not a default.
+//!
+//! Upstream docs: <https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth>
+
+use super::*;
+use crate::config::Node;
+use crate::utils::{domain, exposed_ports, host_config};
+use anyhow::Result;
+use async_trait::async_trait;
+use bollard::{container::Config, Docker};
+use serde::{Deserialize, Serialize};
+
+/// Absolute path to the CLI inside the official image. `hermes` is not on
+/// PATH for `docker exec`, so every exec we issue has to spell it out.
+pub const HERMES_BIN: &str = "/opt/hermes/.venv/bin/hermes";
+
+/// Mutable state dir. The image keeps its immutable app tree under
+/// /opt/hermes and expects writable state at /opt/data, which is where our
+/// named volume lands. HERMES_HOME points the CLI at it so the OAuth
+/// credentials (auth.json) survive container recreation — without it they'd
+/// go to ~/.hermes inside the container layer and be lost on every image
+/// pull by the auto-updater.
+const HERMES_HOME: &str = "/opt/data";
+
+/// The subscription proxy: turns OAuth-backed provider sessions (SuperGrok /
+/// X Premium+ via `auth add xai-oauth`) into an OpenAI-compatible endpoint.
+/// Not the messaging gateway (`gateway run`, port 8642) — that's a different
+/// service.
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct HermesImage {
+    pub name: String,
+    pub version: String,
+    pub port: String,
+    pub links: Links,
+}
+
+impl HermesImage {
+    pub fn new(name: &str, version: &str, port: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            version: version.to_string(),
+            port: port.to_string(),
+            links: vec![],
+        }
+    }
+    pub fn links(&mut self, links: Vec<&str>) {
+        self.links = strarr(links);
+    }
+}
+
+#[async_trait]
+impl DockerConfig for HermesImage {
+    async fn make_config(&self, _nodes: &Vec<Node>, _docker: &Docker) -> Result<Config<String>> {
+        Ok(hermes(self))
+    }
+}
+
+impl DockerHubImage for HermesImage {
+    fn repo(&self) -> Repository {
+        Repository {
+            registry: Registry::DockerHub,
+            org: "nousresearch".to_string(),
+            repo: "hermes-agent".to_string(),
+            root_volume: HERMES_HOME.to_string(),
+        }
+    }
+}
+
+fn hermes(node: &HermesImage) -> Config<String> {
+    let name = node.name.clone();
+    let repo = node.repo();
+    let image = node.image();
+
+    let root_vol = &repo.root_volume;
+    let ports = vec![node.port.clone()];
+
+    let env = vec![format!("HERMES_HOME={}", HERMES_HOME)];
+
+    // No traefik labels: the proxy is an unauthenticated OpenAI-compatible
+    // endpoint sitting on top of your xAI session, so it stays reachable only
+    // inside the sphinx-swarm network (http://hermes.sphinx:PORT).
+    Config {
+        image: Some(format!("{}:{}", image, node.version)),
+        hostname: Some(domain(&name)),
+        exposed_ports: exposed_ports(ports.clone()),
+        cmd: Some(vec![
+            "proxy".to_string(),
+            "start".to_string(),
+            "--port".to_string(),
+            node.port.clone(),
+            "--host".to_string(),
+            "0.0.0.0".to_string(),
+        ]),
+        env: Some(env),
+        // Mirrors stdin_open/tty in the upstream compose example.
+        open_stdin: Some(true),
+        tty: Some(true),
+        host_config: host_config(&name, ports, root_vol, None, None),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hermes_runs_the_proxy_on_its_port() {
+        let img = HermesImage::new("hermes", "latest", "8645");
+        let c = hermes(&img);
+
+        assert_eq!(
+            c.cmd.unwrap(),
+            vec!["proxy", "start", "--port", "8645", "--host", "0.0.0.0"]
+        );
+        assert_eq!(c.image.unwrap(), "nousresearch/hermes-agent:latest");
+        assert_eq!(c.hostname.unwrap(), "hermes.sphinx");
+    }
+
+    #[test]
+    fn test_hermes_home_is_on_the_named_volume() {
+        let img = HermesImage::new("hermes", "latest", "8645");
+        let c = hermes(&img);
+
+        assert!(c
+            .env
+            .unwrap()
+            .contains(&"HERMES_HOME=/opt/data".to_string()));
+
+        // Credentials written under HERMES_HOME must land on the volume, or
+        // they're lost every time the auto-updater recreates the container.
+        let binds = c.host_config.unwrap().binds.unwrap();
+        assert!(
+            binds.iter().any(|b| b == "hermes.sphinx:/opt/data:rw"),
+            "binds should mount the named volume at /opt/data, got: {:?}",
+            binds
+        );
+    }
+}

--- a/src/images/mod.rs
+++ b/src/images/mod.rs
@@ -11,6 +11,7 @@ pub mod config_server;
 pub mod dufs;
 pub mod elastic;
 pub mod graphmindset;
+pub mod hermes;
 pub mod hive_relay;
 pub mod jamie;
 pub mod jarvis;
@@ -83,6 +84,7 @@ pub enum Image {
     Vector(vector::VectorImage),
     HiveRelay(hive_relay::HiveRelayImage),
     Bifrost(bifrost::BifrostImage),
+    Hermes(hermes::HermesImage),
 }
 
 pub enum Registry {
@@ -164,6 +166,7 @@ impl Image {
             Image::Vector(n) => n.name.clone(),
             Image::HiveRelay(n) => n.name.clone(),
             Image::Bifrost(n) => n.name.clone(),
+            Image::Hermes(n) => n.name.clone(),
         }
     }
 
@@ -205,6 +208,8 @@ impl Image {
             Image::Vector(n) => n.host.clone(),
             Image::HiveRelay(n) => n.host.clone(),
             Image::Bifrost(n) => n.host.clone(),
+            // internal only: never fronted by traefik
+            Image::Hermes(_) => None,
         }
     }
     pub fn typ(&self) -> String {
@@ -245,6 +250,7 @@ impl Image {
             Image::Vector(_n) => "Vector",
             Image::HiveRelay(_n) => "HiveRelay",
             Image::Bifrost(_n) => "Bifrost",
+            Image::Hermes(_n) => "Hermes",
         }
         .to_string()
     }
@@ -286,6 +292,7 @@ impl Image {
             Image::Vector(n) => n.version = version.to_string(),
             Image::HiveRelay(n) => n.version = version.to_string(),
             Image::Bifrost(n) => n.version = version.to_string(),
+            Image::Hermes(n) => n.version = version.to_string(),
         }
     }
 
@@ -327,6 +334,7 @@ impl Image {
             Image::Vector(n) => n.host(Some(host.to_string())),
             Image::HiveRelay(n) => n.host(Some(host.to_string())),
             Image::Bifrost(n) => n.host(Some(host.to_string())),
+            Image::Hermes(_) => (),
         }
     }
     pub async fn pre_startup(&self, docker: &Docker, nodes: &Vec<config::Node>) -> Result<()> {
@@ -429,6 +437,7 @@ impl DockerConfig for Image {
             Image::Vector(n) => n.make_config(nodes, docker).await,
             Image::HiveRelay(n) => n.make_config(nodes, docker).await,
             Image::Bifrost(n) => n.make_config(nodes, docker).await,
+            Image::Hermes(n) => n.make_config(nodes, docker).await,
         }
     }
 }
@@ -472,6 +481,7 @@ impl DockerHubImage for Image {
             Image::Vector(n) => n.repo(),
             Image::HiveRelay(n) => n.repo(),
             Image::Bifrost(n) => n.repo(),
+            Image::Hermes(n) => n.repo(),
         }
     }
 }
@@ -550,6 +560,14 @@ impl LinkedImages {
     pub fn find_boltwall(&self) -> Option<boltwall::BoltwallImage> {
         for img in self.0.iter() {
             if let Ok(i) = img.as_boltwall() {
+                return Some(i);
+            }
+        }
+        None
+    }
+    pub fn find_hermes(&self) -> Option<hermes::HermesImage> {
+        for img in self.0.iter() {
+            if let Ok(i) = img.as_hermes() {
                 return Some(i);
             }
         }
@@ -832,6 +850,12 @@ impl Image {
         match self {
             Image::Bifrost(i) => Ok(i.clone()),
             _ => Err(anyhow::anyhow!("Not Bifrost".to_string())),
+        }
+    }
+    pub fn as_hermes(&self) -> anyhow::Result<hermes::HermesImage> {
+        match self {
+            Image::Hermes(i) => Ok(i.clone()),
+            _ => Err(anyhow::anyhow!("Not Hermes".to_string())),
         }
     }
 }

--- a/src/images/repo2graph.rs
+++ b/src/images/repo2graph.rs
@@ -2,6 +2,7 @@ use super::traefik::traefik_labels;
 use super::*;
 use crate::config::Node;
 use crate::images::boltwall::BoltwallImage;
+use crate::images::hermes::HermesImage;
 use crate::images::jarvis::JarvisImage;
 use crate::images::neo4j::Neo4jImage;
 use crate::images::traefik::shared_host;
@@ -55,7 +56,8 @@ impl DockerConfig for Repo2GraphImage {
         let neo4j = li.find_neo4j().context("Repo2Graph: No Neo4j")?;
         let boltwall = li.find_boltwall();
         let jarvis = li.find_jarvis();
-        Ok(repo2graph(self, &neo4j, &boltwall, &jarvis)?)
+        let hermes = li.find_hermes();
+        Ok(repo2graph(self, &neo4j, &boltwall, &jarvis, &hermes)?)
     }
 }
 
@@ -75,6 +77,7 @@ fn repo2graph(
     neo4j: &Neo4jImage,
     boltwall: &Option<BoltwallImage>,
     jarvis: &Option<JarvisImage>,
+    hermes: &Option<HermesImage>,
 ) -> Result<Config<String>> {
     let repo = img.repo();
     let image = img.image();
@@ -103,6 +106,9 @@ fn repo2graph(
     }
     if let Some(j) = jarvis {
         env.push(format!("JARVIS_URL=http://{}:{}", domain(&j.name), j.port));
+    }
+    if let Some(h) = hermes {
+        env.push(format!("HERMES_URL=http://{}:{}", domain(&h.name), h.port));
     }
 
     if let Ok(openai_api_key) = getenv("OPENAI_API_KEY") {
@@ -179,7 +185,7 @@ mod tests {
 
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
-        let config = repo2graph(&img, &neo4j, &None, &None).unwrap();
+        let config = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
         let env = config.env.unwrap();
 
         assert!(
@@ -200,7 +206,7 @@ mod tests {
 
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
-        let config = repo2graph(&img, &neo4j, &None, &None).unwrap();
+        let config = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
 
         let binds = config
             .host_config
@@ -218,6 +224,33 @@ mod tests {
     }
 
     #[test]
+    fn test_hermes_url_is_emitted_only_when_linked() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        let img = test_repo2graph_image();
+        let neo4j = test_neo4j_image();
+
+        let without = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
+        assert!(
+            !without
+                .env
+                .unwrap()
+                .iter()
+                .any(|e| e.starts_with("HERMES_URL=")),
+            "HERMES_URL should be absent when hermes isn't linked"
+        );
+
+        let hermes = HermesImage::new("hermes", "latest", "8645");
+        let with = repo2graph(&img, &neo4j, &None, &None, &Some(hermes)).unwrap();
+        assert!(
+            with.env
+                .unwrap()
+                .contains(&"HERMES_URL=http://hermes.sphinx:8645".to_string()),
+            "HERMES_URL should point at the hermes container"
+        );
+    }
+
+    #[test]
     fn test_sessions_and_artifacts_vols_still_present() {
         let _lock = ENV_LOCK.lock().unwrap();
 
@@ -228,7 +261,7 @@ mod tests {
 
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
-        let config = repo2graph(&img, &neo4j, &None, &None).unwrap();
+        let config = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
 
         let env = config.env.as_ref().unwrap();
         assert!(env.contains(&"SESSIONS_DIR=/usr/src/app/sessions".to_string()));

--- a/src/images/repo2graph.rs
+++ b/src/images/repo2graph.rs
@@ -225,8 +225,8 @@ mod tests {
 
     #[test]
     fn test_hermes_url_is_emitted_only_when_linked() {
-        let _lock = ENV_LOCK.lock().unwrap();
-
+        // Deliberately does not take ENV_LOCK: nothing here reads or writes
+        // env vars, and the assertions only look at HERMES_URL.
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod events;
 pub mod fast_service_update;
 pub mod graphmindset;
 pub mod handler;
+pub mod hermes_auth;
 pub mod images;
 pub mod logs;
 pub mod mount_backedup_volume;

--- a/src/secondbrain.rs
+++ b/src/secondbrain.rs
@@ -5,6 +5,7 @@ use crate::images::bot::BotImage;
 use crate::images::graphmindset::GraphMindsetImage;
 use crate::images::bifrost::BifrostImage;
 use crate::images::hive_relay::HiveRelayImage;
+use crate::images::hermes::HermesImage;
 use crate::images::jarvis::JarvisImage;
 use crate::images::llama::LlamaImage;
 use crate::images::navfiber::NavFiberImage;
@@ -73,11 +74,15 @@ pub fn second_brain_imgs(host: Option<String>, lightning_provider: &str) -> Vec<
     let mut jarvis = JarvisImage::new("jarvis", v, "6000", false);
     jarvis.links(vec!["neo4j", "elastic", "boltwall", "redis"]);
 
+    // hermes (subscription proxy for OAuth-backed LLM providers)
+    v = "latest";
+    let hermes = HermesImage::new("hermes", v, "8645");
+
     // repo2graph
     v = "latest";
     let mut repo2graph = Repo2GraphImage::new("repo2graph", v, "3355");
     repo2graph.host(host.clone());
-    repo2graph.links(vec!["neo4j", "boltwall", "bifrost", "jarvis"]);
+    repo2graph.links(vec!["neo4j", "boltwall", "bifrost", "jarvis", "hermes"]);
 
     // stakgraph
     v = "latest";
@@ -149,6 +154,7 @@ pub fn second_brain_imgs(host: Option<String>, lightning_provider: &str) -> Vec<
         Image::Jarvis(jarvis),
         Image::Redis(redis),
         Image::Repo2Graph(repo2graph),
+        Image::Hermes(hermes),
         Image::Stakgraph(stakgraph),
         Image::Quickwit(quickwit),
         Image::Vector(vector),


### PR DESCRIPTION
Adds Hermes Agent's **subscription proxy** — the component that turns an OAuth-backed provider session (SuperGrok / X Premium+ via xAI OAuth) into a local OpenAI-compatible endpoint. Not the messaging gateway (`gateway run`, 8642), which is a different service.

repo2graph gets `HERMES_URL=http://hermes.sphinx:8645`.

## Why auth is brokered through swarm

The original idea was to run `docker compose exec -it hermes-proxy hermes auth add xai-oauth` from repo2graph. That doesn't work, for two independent reasons:

- **`docker compose exec` can't work at all.** Swarm creates these containers with bollard directly (`builder.rs`), not compose — there's no compose project to resolve against. The host-side equivalent would be `docker exec -it hermes.sphinx ...`.
- **Doing it from repo2graph** would need `/var/run/docker.sock` bind-mounted into it *plus* a docker CLI in the `stakgraph-mcp` image. The socket is root-equivalent on the host, and repo2graph runs LLM-directed code over arbitrary cloned repos. Not worth the trade.

Swarm already holds the socket, so it brokers the exec.

## Shape of the flow

`hermes auth add xai-oauth --no-browser` is a **device-code** flow: it prints a verification URL and user code within about a second, then polls xAI for minutes until a human approves in a browser. No stdin, no TTY — but far too slow to hold an HTTP request open. So:

- `HermesAuthStart` blocks only until the URL is on the wire (8s cap), backgrounds the rest, returns `{session_id, provider, output, done, exit_code}`
- `HermesAuthStatus` is polled with the `session_id` until `done`
- `HermesAuthList` / `HermesAuthLogout` are synchronous

**No UI** — all four are driven over the existing admin-JWT `/api/cmd` endpoint. Full curl examples are in the doc block at the top of `src/images/hermes.rs`.

## Notes for review

- `HERMES_HOME` is pinned to the named volume. The CLI otherwise writes credentials to `~/.hermes` inside the container layer, where the auto-updater would drop them on every image pull. There's a test asserting the bind.
- **No traefik labels**, deliberately — the proxy is an unauthenticated OpenAI-compatible endpoint sitting on your xAI session, so it stays internal to the sphinx-swarm network.
- **Not added to any `auto_update` list.** Those are all Sphinx/stakwork images; auto-recreating a third-party `:latest` on every upstream push felt like an opt-in call. Easy to add if you want it.
- `provider` is interpolated into an exec argv, so it's validated to `[a-z0-9-]` and rejected if it leads with `-` (otherwise `--help` and friends sail through).
- Added to both the `graph_mindset` and second-brain presets, plus `migrate_stack` so existing swarms pick it up.

## Testing

`cargo test --lib` — 31 passed, 0 failed. New coverage for the proxy command/port, the HERMES_HOME volume bind, conditional `HERMES_URL` emission, and provider validation.

Not verified: the one-line `NodeType` addition in `app/src/nodes.ts` (type plumbing only — `Controller.svelte` falls through to `DefaultNode`, so no UI renders). `app/node_modules` isn't installed locally, so `yarn check` didn't run.

Upstream docs: https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth

🤖 Generated with [Claude Code](https://claude.com/claude-code)