### PR TITLE
Stop hermes crash-looping when it has no credentials

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -25,6 +25,55 @@ pub fn shutdown_now() {
     SHUTDOWN.store(true, Ordering::Relaxed);
 }
 
+/// One-time repair for hermes containers created before the retry-loop command
+/// landed. Those ran `hermes proxy start` directly as PID 1, which exits at
+/// once when no credential is stored — so `restart: unless-stopped` turned
+/// them into a crash loop, with nothing running to exec a login into.
+///
+/// `create_and_init` returns early for containers that already exist, so a
+/// swarm upgrade alone never replaces them. Compare the live container's Cmd
+/// against what we'd generate now and remove it if they differ; the normal
+/// build path immediately recreates it with the current config. Idempotent,
+/// and it picks up any future command change for free.
+///
+/// Deliberately best-effort: a failure here must not block the rest of the
+/// stack from starting.
+async fn recreate_stale_hermes(docker: &Docker, stack: &Stack) -> Result<()> {
+    let node = match stack.nodes.iter().find(|n| n.name() == "hermes") {
+        Some(n) => n,
+        None => return Ok(()),
+    };
+    let img = match node.as_internal() {
+        Ok(Image::Hermes(h)) => h,
+        _ => return Ok(()),
+    };
+
+    let hostname = domain(&img.name);
+    let id = match id_by_name(docker, &hostname).await {
+        Some(id) => id,
+        None => return Ok(()),
+    };
+
+    let desired = img.make_config(&stack.nodes, docker).await?.cmd;
+    let current = docker
+        .inspect_container(&hostname, None)
+        .await?
+        .config
+        .and_then(|c| c.cmd);
+
+    if current == desired {
+        return Ok(());
+    }
+
+    log::info!(
+        "=> hermes container has a stale command, recreating (was {:?})",
+        current
+    );
+    let _ = stop_container(docker, &id).await;
+    remove_container(docker, &id).await?;
+    Ok(())
+}
+
 // return a map of name:docker_id
 pub async fn build_stack(proj: &str, docker: &Docker, stack: &Stack) -> Result<ClientMap> {
     // set global mem limit if it exists
@@ -34,6 +83,10 @@ pub async fn build_stack(proj: &str, docker: &Docker, stack: &Stack) -> Result<C
     }
     // first create the default network
     create_network(docker, None).await?;
+    // repair containers whose baked-in command is stale before we build
+    if let Err(e) = recreate_stale_hermes(docker, stack).await {
+        log::warn!("recreate_stale_hermes failed: {:?}", e);
+    }
     // then add the containers
     let mut clients: ClientMap = Default::default();
     let nodes = stack.nodes.clone();

--- a/src/hermes_auth.rs
+++ b/src/hermes_auth.rs
@@ -86,11 +86,16 @@ pub async fn start(docker: &Docker, provider: &str) -> Result<AuthSession> {
     let provider = validate_provider(provider)?;
     let container = domain(HERMES_NODE);
 
+    // --type oauth is what the container's own "not logged in" message tells
+    // you to run; --no-browser keeps it from trying to spawn one and makes it
+    // print the verification URL instead.
     let cmd = vec![
         HERMES_BIN.to_string(),
         "auth".to_string(),
         "add".to_string(),
         provider.clone(),
+        "--type".to_string(),
+        "oauth".to_string(),
         "--no-browser".to_string(),
     ];
 
@@ -179,10 +184,17 @@ pub async fn status(session_id: &str) -> Result<AuthSession> {
     }
 }
 
-/// `hermes auth list <provider>` — fast, exits on its own.
+/// Login state plus stored credentials for a provider.
+///
+/// `auth list` alone is not enough: with nothing stored it prints an empty
+/// string and exits 0, which tells a caller nothing. `auth status` is the one
+/// that actually answers "am I logged in?" ("xai-oauth: logged out (...)"), so
+/// both run and the output is concatenated.
 pub async fn list(docker: &Docker, provider: &str) -> Result<String> {
     let provider = validate_provider(provider)?;
-    run(docker, vec!["auth", "list", &provider]).await
+    let status = run(docker, vec!["auth", "status", &provider]).await?;
+    let list = run(docker, vec!["auth", "list", &provider]).await?;
+    Ok(format!("{}{}", status, list))
 }
 
 /// `hermes auth logout <provider>` — drops every stored credential for it.

--- a/src/images/hermes.rs
+++ b/src/images/hermes.rs
@@ -86,8 +86,14 @@
 //!
 //! # Gotchas
 //!
-//!   - `hermes` is **not on PATH** for `docker exec`; the CLI lives in a venv.
-//!     Hence `HERMES_BIN` below.
+//!   - `proxy start` **exits immediately** when no credential is stored. As a
+//!     bare container command that crash-loops under `restart: unless-stopped`
+//!     and leaves nothing to exec into, so PID 1 is a retry loop instead —
+//!     see `proxy_command`. The container is up but idle until someone logs
+//!     in, then picks the proxy up on its own within ~30s.
+//!   - `create_and_init` skips containers that already exist, so changing the
+//!     command here does **not** reach deployed swarms. `recreate_stale_hermes`
+//!     in `builder.rs` removes mismatched containers on boot.
 //!   - `HERMES_HOME` must point at the named volume or credentials are lost on
 //!     every image pull by the auto-updater. See the test at the bottom.
 //!   - `proxy start` defaults to `--provider nous`. We pass `--provider xai`
@@ -111,8 +117,10 @@ use async_trait::async_trait;
 use bollard::{container::Config, Docker};
 use serde::{Deserialize, Serialize};
 
-/// Absolute path to the CLI inside the official image. `hermes` is not on
-/// PATH for `docker exec`, so every exec we issue has to spell it out.
+/// Absolute path to the CLI inside the official image. `hermes` does resolve
+/// on PATH for `docker exec` (the image's PATH carries /opt/hermes/bin), but
+/// the absolute venv path is stable regardless of how the entrypoint sets up
+/// the environment, so execs spell it out.
 pub const HERMES_BIN: &str = "/opt/hermes/.venv/bin/hermes";
 
 /// Mutable state dir. The image keeps its immutable app tree under
@@ -179,6 +187,39 @@ impl DockerHubImage for HermesImage {
     }
 }
 
+/// The proxy command, wrapped in a retry loop.
+///
+/// `proxy start` exits immediately with "Not logged into xAI Grok OAuth" when
+/// no credential is stored. Run as the container's whole command that kills
+/// the container, and `restart: unless-stopped` turns it into a crash loop —
+/// which also means there's no running container to exec the login into.
+///
+/// So PID 1 is a shell that keeps retrying instead. The container stays up
+/// unauthenticated (doing nothing useful, but alive and exec-able), and picks
+/// the proxy up on its own within `RETRY_SECS` of a successful login. No
+/// redeploy needed after authenticating.
+///
+/// `main-wrapper.sh` routes the container CMD three ways: no args runs
+/// `hermes`, a first arg that resolves as an executable is exec'd directly,
+/// and anything else is passed through as a `hermes` subcommand. `sh` takes
+/// the executable path, and `hermes` is on PATH inside it.
+fn proxy_command(node: &HermesImage) -> Vec<String> {
+    let start = format!(
+        "hermes proxy start --provider {} --host 0.0.0.0 --port {}",
+        node.provider, node.port
+    );
+    vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!(
+            "while true; do {};              echo \"[swarm] hermes proxy exited (not logged in?); retrying in {}s\";              sleep {}; done",
+            start, RETRY_SECS, RETRY_SECS
+        ),
+    ]
+}
+
+const RETRY_SECS: u32 = 30;
+
 fn hermes(node: &HermesImage) -> Config<String> {
     let name = node.name.clone();
     let repo = node.repo();
@@ -187,6 +228,8 @@ fn hermes(node: &HermesImage) -> Config<String> {
     let root_vol = &repo.root_volume;
     let ports = vec![node.port.clone()];
 
+    // The image already sets HERMES_HOME=/opt/data itself; we set it anyway so
+    // the invariant is visible here and survives an upstream default change.
     let env = vec![format!("HERMES_HOME={}", HERMES_HOME)];
 
     // The proxy accepts ANY bearer token — it attaches the real OAuth
@@ -198,16 +241,7 @@ fn hermes(node: &HermesImage) -> Config<String> {
         image: Some(format!("{}:{}", image, node.version)),
         hostname: Some(domain(&name)),
         exposed_ports: exposed_ports(ports),
-        cmd: Some(vec![
-            "proxy".to_string(),
-            "start".to_string(),
-            "--provider".to_string(),
-            node.provider.clone(),
-            "--port".to_string(),
-            node.port.clone(),
-            "--host".to_string(),
-            "0.0.0.0".to_string(),
-        ]),
+        cmd: Some(proxy_command(node)),
         env: Some(env),
         // Mirrors stdin_open/tty in the upstream compose example.
         open_stdin: Some(true),
@@ -226,13 +260,22 @@ mod tests {
         let img = HermesImage::new("hermes", "latest", "8645");
         let c = hermes(&img);
 
+        let cmd = c.cmd.unwrap();
+
+        // PID 1 must be a shell loop, not `proxy start` directly: the latter
+        // exits when unauthenticated and crash-loops the container, leaving
+        // nothing to exec the login into.
+        assert_eq!(cmd[0], "sh");
+        assert_eq!(cmd[1], "-c");
+        assert!(cmd[2].starts_with("while true; do "), "got: {}", cmd[2]);
+        assert!(cmd[2].contains("sleep 30"), "got: {}", cmd[2]);
+
         // --provider matters: `proxy start` defaults to nous, so without it
         // an xai-oauth login would serve the wrong upstream.
-        assert_eq!(
-            c.cmd.unwrap(),
-            vec![
-                "proxy", "start", "--provider", "xai", "--port", "8645", "--host", "0.0.0.0"
-            ]
+        assert!(
+            cmd[2].contains("hermes proxy start --provider xai --host 0.0.0.0 --port 8645"),
+            "got: {}",
+            cmd[2]
         );
         assert_eq!(c.image.unwrap(), "nousresearch/hermes-agent:latest");
         assert_eq!(c.hostname.unwrap(), "hermes.sphinx");


### PR DESCRIPTION
Fixes the crash loop from #729. Every swarm that picked up the hermes node is currently restarting it forever.

## What broke

`hermes proxy start` exits immediately when no credential is stored:

```
Not logged into xAI Grok OAuth. Run `hermes auth add xai-oauth --type oauth` first.
```

As the container's whole command, that kills the container, and `restart: unless-stopped` loops it. Worse, it defeats the design of #729 entirely — the login is delivered by `docker exec`, and there's no running container to exec into.

## The fix

PID 1 is a shell retry loop instead of `proxy start` directly. The container stays up but idle while unauthenticated, and picks the proxy up on its own within ~30s of a successful login — no redeploy needed.

This works because the image's `main-wrapper.sh` routes CMD three ways: no args runs `hermes`, **a first arg that resolves as an executable is exec'd directly**, and anything else is a `hermes` subcommand passthrough. `sh` takes the executable path.

Verified against `nousresearch/hermes-agent:latest` (v0.20.5) using the exact string the Rust code generates, not an approximation of it:

```
status=running restarts=0
```

...with the retry logged every 30s and `docker exec` working throughout. Also confirmed the device-code flow behaves as #729 assumed — `auth add xai-oauth --type oauth --no-browser` printed a verification URL and user code within seconds, then polled.

## Existing swarms need migration

A code change alone would **not** have fixed anything deployed. `create_and_init` returns early on `"already exists"`, so the stale command survives a swarm upgrade indefinitely.

`recreate_stale_hermes` compares the live container's `Cmd` against what we'd generate now and removes it if they differ; the normal build path then recreates it. Idempotent, best-effort (a failure logs and can't block stack startup), and it covers any future command change for free.

## Corrections found by testing against the image

Several things in #729 came from docs that turned out to be wrong or incomplete:

- **`auth add` now passes `--type oauth`** — what the container's own error message instructs.
- **`auth list` prints nothing at all** when no credential is stored, exit 0. So `HermesAuthList` was returning an empty string, which tells a caller nothing. It now also runs `auth status`, which is the call that actually reports logged in/out (`xai-oauth: logged out (...)`).
- **`hermes` does resolve on PATH** for `docker exec` — the image's PATH carries `/opt/hermes/bin`. The old comment claimed otherwise. `HERMES_BIN` stays absolute anyway since it's stable regardless of entrypoint setup.
- **`HERMES_HOME=/opt/data` is already set by the image.** Ours is redundant, kept so the invariant is visible and survives an upstream default change.
- `--provider xai` and the `--host`/`--port` flags from #729 were confirmed correct against `proxy start --help`.

## Testing

`cargo test --lib` — 32 passed, 5 consecutive clean runs.

Heads up: the suite is **intermittently flaky**, and it bit twice during this work (once `28 passed; 4 failed`, once `26 passed; 6 failed`, both on the first run after a fresh compile, both clean on every rerun). Cause is unrelated to this PR: `repo2graph.rs`, `bifrost.rs`, and `utils.rs` each declare their own private `ENV_LOCK` mutex while all three mutate the same global env vars, so they don't exclude each other. Worth fixing separately with one shared lock.

## Still unresolved

Your log also showed this, which I haven't chased:

```
[config-migrate] WARNING: This config predates version 12 (~2 years old) and can no longer be auto-migrated.
```

It appears on a fresh volume, which is odd. It doesn't stop the container from running, so it's not blocking, but it may want a look before hermes is relied on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)