### PR TITLE
[Jamie] Inject boltwall TESTING_FREE under the name the app reads

### DIFF
--- a/src/images/boltwall.rs
+++ b/src/images/boltwall.rs
@@ -285,7 +285,7 @@ fn boltwall(
 
     match getenv("BOLTWALL_TESTING_FREE") {
         Ok(env_value) => {
-            env.push(format!("BOLTWALL_TESTING_FREE={}", env_value));
+            env.push(format!("TESTING_FREE={}", env_value));
         }
         Err(err) => {
             log::error!("Error geting env host: {}", err.to_string())


### PR DESCRIPTION
The boltwall container was being given the free-testing flag under the wrong env var name.

`sphinx-swarm` reads the host var `BOLTWALL_TESTING_FREE` and injected it into the boltwall container under the identical name. But `jarvis-boltwall`'s `paymentDeterminer.ts` only reads `process.env.TESTING_FREE` — it has never read `BOLTWALL_TESTING_FREE`. As a result the free-testing payment bypass (`?free=true` + `TESTING_FREE=true`) never activated when the flag was set via the swarm.

This changes only the injected variable name so the container receives `TESTING_FREE`, while keeping `BOLTWALL_TESTING_FREE` as the operator-facing host var name. Restores the ability to hit paid routes (e.g. `/v2/content?free=true`, formerly `/add_node?free=true`) for free in testing deployments.