### PR TITLE
Add REDIS_URL to repo2graph

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -437,6 +437,12 @@ pub fn migrate_stack(stack: &mut Stack) {
                     img.links.push("hermes".to_string());
                     log::info!("=> added hermes link to repo2graph");
                 }
+                // Existing swarms predate the repo2graph↔redis link; add
+                // it on migration so REDIS_URL gets set. Idempotent.
+                if !img.links.contains(&"redis".to_string()) {
+                    img.links.push("redis".to_string());
+                    log::info!("=> added redis link to repo2graph");
+                }
             }
             Node::Internal(Image::Stakgraph(ref mut img)) => {
                 if !img.links.contains(&"bifrost".to_string()) {

--- a/src/graphmindset.rs
+++ b/src/graphmindset.rs
@@ -93,7 +93,7 @@ pub fn graph_mindset_imgs(_network: &str, host: Option<String>) -> Vec<Image> {
     v = "latest";
     let mut repo2graph = Repo2GraphImage::new("repo2graph", v, "3355");
     repo2graph.host(host.clone());
-    repo2graph.links(vec!["neo4j", "boltwall", "jarvis", "hermes"]);
+    repo2graph.links(vec!["neo4j", "boltwall", "jarvis", "hermes", "redis"]);
 
     // stakgraph
     v = "latest";

--- a/src/images/repo2graph.rs
+++ b/src/images/repo2graph.rs
@@ -5,6 +5,7 @@ use crate::images::boltwall::BoltwallImage;
 use crate::images::hermes::HermesImage;
 use crate::images::jarvis::JarvisImage;
 use crate::images::neo4j::Neo4jImage;
+use crate::images::redis::RedisImage;
 use crate::images::traefik::shared_host;
 use crate::utils::{domain, exposed_ports, getenv, host_config, volume_string};
 use anyhow::{Context, Result};
@@ -57,7 +58,8 @@ impl DockerConfig for Repo2GraphImage {
         let boltwall = li.find_boltwall();
         let jarvis = li.find_jarvis();
         let hermes = li.find_hermes();
-        Ok(repo2graph(self, &neo4j, &boltwall, &jarvis, &hermes)?)
+        let redis = li.find_redis();
+        Ok(repo2graph(self, &neo4j, &boltwall, &jarvis, &hermes, &redis)?)
     }
 }
 
@@ -78,6 +80,7 @@ fn repo2graph(
     boltwall: &Option<BoltwallImage>,
     jarvis: &Option<JarvisImage>,
     hermes: &Option<HermesImage>,
+    redis: &Option<RedisImage>,
 ) -> Result<Config<String>> {
     let repo = img.repo();
     let image = img.image();
@@ -109,6 +112,9 @@ fn repo2graph(
     }
     if let Some(h) = hermes {
         env.push(format!("HERMES_URL=http://{}:{}", domain(&h.name), h.port));
+    }
+    if let Some(r) = redis {
+        env.push(format!("REDIS_URL=redis://{}:{}", domain(&r.name), r.http_port));
     }
 
     if let Ok(openai_api_key) = getenv("OPENAI_API_KEY") {
@@ -185,7 +191,7 @@ mod tests {
 
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
-        let config = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
+        let config = repo2graph(&img, &neo4j, &None, &None, &None, &None).unwrap();
         let env = config.env.unwrap();
 
         assert!(
@@ -206,7 +212,7 @@ mod tests {
 
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
-        let config = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
+        let config = repo2graph(&img, &neo4j, &None, &None, &None, &None).unwrap();
 
         let binds = config
             .host_config
@@ -230,7 +236,7 @@ mod tests {
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
 
-        let without = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
+        let without = repo2graph(&img, &neo4j, &None, &None, &None, &None).unwrap();
         assert!(
             !without
                 .env
@@ -241,12 +247,39 @@ mod tests {
         );
 
         let hermes = HermesImage::new("hermes", "latest", "8645");
-        let with = repo2graph(&img, &neo4j, &None, &None, &Some(hermes)).unwrap();
+        let with = repo2graph(&img, &neo4j, &None, &None, &Some(hermes), &None).unwrap();
         assert!(
             with.env
                 .unwrap()
                 .contains(&"HERMES_URL=http://hermes.sphinx:8645".to_string()),
             "HERMES_URL should point at the hermes container"
+        );
+    }
+
+    #[test]
+    fn test_redis_url_is_emitted_only_when_linked() {
+        // Deliberately does not take ENV_LOCK: nothing here reads or writes
+        // env vars, and the assertions only look at REDIS_URL.
+        let img = test_repo2graph_image();
+        let neo4j = test_neo4j_image();
+
+        let without = repo2graph(&img, &neo4j, &None, &None, &None, &None).unwrap();
+        assert!(
+            !without
+                .env
+                .unwrap()
+                .iter()
+                .any(|e| e.starts_with("REDIS_URL=")),
+            "REDIS_URL should be absent when redis isn't linked"
+        );
+
+        let redis = RedisImage::new("redis", "latest");
+        let with = repo2graph(&img, &neo4j, &None, &None, &None, &Some(redis)).unwrap();
+        assert!(
+            with.env
+                .unwrap()
+                .contains(&"REDIS_URL=redis://redis.sphinx:6379".to_string()),
+            "REDIS_URL should point at the redis container"
         );
     }
 
@@ -261,7 +294,7 @@ mod tests {
 
         let img = test_repo2graph_image();
         let neo4j = test_neo4j_image();
-        let config = repo2graph(&img, &neo4j, &None, &None, &None).unwrap();
+        let config = repo2graph(&img, &neo4j, &None, &None, &None, &None).unwrap();
 
         let env = config.env.as_ref().unwrap();
         assert!(env.contains(&"SESSIONS_DIR=/usr/src/app/sessions".to_string()));

--- a/src/secondbrain.rs
+++ b/src/secondbrain.rs
@@ -82,7 +82,7 @@ pub fn second_brain_imgs(host: Option<String>, lightning_provider: &str) -> Vec<
     v = "latest";
     let mut repo2graph = Repo2GraphImage::new("repo2graph", v, "3355");
     repo2graph.host(host.clone());
-    repo2graph.links(vec!["neo4j", "boltwall", "bifrost", "jarvis", "hermes"]);
+    repo2graph.links(vec!["neo4j", "boltwall", "bifrost", "jarvis", "hermes", "redis"]);
 
     // stakgraph
     v = "latest";


### PR DESCRIPTION
## Summary
- Link `redis` to repo2graph in the graph-mindset and second-brain presets and emit `REDIS_URL=redis://redis.sphinx:6379` (only when a redis node is linked)
- Retrofit the link on existing swarms via `migrate_stack()` on boot — idempotent, same pattern as the jarvis/hermes/bifrost link migrations
- Add a test asserting `REDIS_URL` is emitted only when redis is linked

Note: jarvis gets redis as `CACHE_REDIS_HOST`/`CACHE_REDIS_PORT`; the `redis://` URL form here follows bifrost's convention.

## Test plan
- `cargo test --lib images::repo2graph` — 5 tests pass, including the new `test_redis_url_is_emitted_only_when_linked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)