### PR TITLE
compose: pass HF_TOKEN through to the sphinx-swarm container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - SUPER_TOKEN=$SUPER_TOKEN
       - QUESTION_AND_ANSWER_WORKFLOW_ID=$QUESTION_AND_ANSWER_WORKFLOW_ID
       - AWS_S3_BUCKET_NAME=$AWS_S3_BUCKET_NAME
+      - HF_TOKEN=$HF_TOKEN # repo2graph GAIA dataset bootstrap (gated HF repo)
 
 networks:
   sphinx-swarm:

--- a/second-brain-2.yml
+++ b/second-brain-2.yml
@@ -140,6 +140,7 @@ services:
       - OPENROUTER_API_KEY=$OPENROUTER_API_KEY
       - GUNICORN_WORKER=$GUNICORN_WORKER
       - GUNICORN_THREADS=$GUNICORN_THREADS
+      - HF_TOKEN=$HF_TOKEN
   node_exporter:
     image: quay.io/prometheus/node-exporter:latest
     container_name: node_exporter


### PR DESCRIPTION
Follow-up to #737. The swarm service's `environment:` block is an explicit allowlist — compose substitutes `.env` vars, but a var not listed there never enters the swarm container, and `repo2graph`'s `make_config` reads `HF_TOKEN` from the swarm process env (`getenv`). So adding `HF_TOKEN` to `.env` alone silently goes nowhere (exactly what we just observed on a live swarm: token in `.env`, repo2graph restarted, no `HF_TOKEN` in the container).

One line: `- HF_TOKEN=$HF_TOKEN` under the sphinx-swarm service.

Deploy note: after this lands, apply it with `docker compose up -d sphinx-swarm` (recreate — a plain `restart` keeps the old env), then restart repo2graph from the swarm UI so `make_config` re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)