### PR TITLE
cln: move to ghcr.io/stakwork/cln-sphinx (v0.4.0, CLN v26.06.7)

### DIFF
--- a/app/src/helpers/swarm.ts
+++ b/app/src/helpers/swarm.ts
@@ -74,6 +74,11 @@ export async function handleGetImageTags(node_name: string): Promise<string[]> {
     host = "Github";
   }
 
+  if (node_name === "cln") {
+    fullName = `stakwork/cln-sphinx`;
+    host = "Github";
+  }
+
   const response = await get_image_tags(fullName, "1", "100", host);
 
   const tags = [];

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -1,7 +1,7 @@
 docker image prune -af
 docker pull sphinxlightning/sphinx-swarm:latest
 docker pull sphinxlightning/sphinx-proxy:latest
-docker pull sphinxlightning/cln-sphinx:latest
+docker pull ghcr.io/stakwork/cln-sphinx:latest
 docker pull sphinxlightning/sphinx-relay-swarm:latest
 docker pull sphinxlightning/sphinx-cache:latest
 docker pull sphinxlightning/sphinx-boltwall:latest

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -16,7 +16,7 @@ docker pull sphinxlightning/sphinx-swarm:latest
 docker pull sphinxlightning/sphinx-tribes-v2:latest
 docker pull sphinxlightning/sphinx-bot:latest
 docker pull sphinxlightning/sphinx-builtin-bots:latest
-docker pull sphinxlightning/cln-sphinx:latest
+docker pull ghcr.io/stakwork/cln-sphinx:latest
 
 echo "stop swarm.sphinx"
 docker stop swarm.sphinx

--- a/scripts/v2.sh
+++ b/scripts/v2.sh
@@ -2,7 +2,7 @@ docker pull sphinxlightning/sphinx-swarm:latest
 docker pull sphinxlightning/sphinx-broker:latest
 docker pull sphinxlightning/sphinx-mixer:latest
 docker pull sphinxlightning/sphinx-tribes-v2:latest
-docker pull sphinxlightning/cln-sphinx:latest
+docker pull ghcr.io/stakwork/cln-sphinx:latest
 docker pull sphinxlightning/sphinx-bot:latest
 docker pull sphinxlightning/sphinx-builtin-bots:latest
 

--- a/src/dock.rs
+++ b/src/dock.rs
@@ -116,7 +116,6 @@ pub async fn create_and_start(
 fn m1_not_supported(from_image: &str) -> bool {
     let vs = vec![
         "/sphinx-lss".to_string(),
-        "/cln-sphinx".to_string(),
         "/sphinx-nav-fiber".to_string(),
         "/stakgraph-mcp".to_string(),
     ];

--- a/src/images/cln.rs
+++ b/src/images/cln.rs
@@ -171,8 +171,8 @@ impl DockerConfig for ClnImage {
 impl DockerHubImage for ClnImage {
     fn repo(&self) -> Repository {
         Repository {
-            registry: Registry::DockerHub,
-            org: "sphinxlightning".to_string(),
+            registry: Registry::Ghcr,
+            org: "stakwork".to_string(),
             repo: "cln-sphinx".to_string(),
             root_volume: "/root/.lightning".to_string(),
         }
@@ -321,6 +321,13 @@ fn cln(img: &ClnImage, btc: ClnBtcArgs, lss: Option<lss::LssImage>) -> Config<St
         cmd.push("--offline".to_string());
     }
     if let Some(hsms) = &img.seed {
+        // CLN 26.06+ only accepts dev-force-* options under --developer, and
+        // --developer disables deprecated RPCs (pay, getroute) that the mixer
+        // still uses, so re-enable them explicitly.
+        if !cmd.iter().any(|c| c == "--developer") {
+            cmd.push("--developer".to_string());
+        }
+        cmd.push("--allow-deprecated-apis=true".to_string());
         cmd.push(format!("--dev-force-bip32-seed={}", hsms));
         let privkey = privkey_from_seed(&hsms).expect("bad seed");
         cmd.push(format!("--dev-force-privkey={}", privkey));


### PR DESCRIPTION
## Summary
- `src/images/cln.rs`: CLN image is now `ghcr.io/stakwork/cln-sphinx` (`Registry::Ghcr`, org `stakwork`). When a seed is set, `--developer` (if not already present) and `--allow-deprecated-apis=true` are added: CLN 26.06 rejects `--dev-force-bip32-seed`/`--dev-force-privkey` without `--developer`, and `--developer` alone switches off the deprecated `pay`/`getroute` RPCs the mixer still uses.
- `src/dock.rs`: `cln-sphinx` removed from the amd64-only list (the GHCR image is multi-arch).
- `scripts/pull.sh`, `scripts/update.sh`, `scripts/v2.sh`: pull from GHCR.
- `app/src/helpers/swarm.ts`: tag listing for `cln` reads from GitHub packages.

Background and rollout procedure: `docs/cln-upgrade.md` in stakwork/sphinx.

## Verification
Tested end to end on a local regtest three-swarm stack (`cargo run --bin sphinx`) against `ghcr.io/stakwork/cln-sphinx:v0.4.0` (CLN v26.06.7): forced-seed pubkeys unchanged, `cln-grpc` and the HTLC interceptor plugin load with this command line, mixer gRPC + gateway attach cleanly, `pay` (via xpay), `getroute`, keysends, cross-swarm payments through the interceptor, boosts and tribe payments all settled with zero failed forwards. Full report with log lines: stakwork/sphinx#345 (`docs/cln-upgrade-local-test-report.md`).

Two things surfaced by that run that are **not** in this PR:
- The v2 images (`sphinx-broker`, `sphinx-mixer`, `sphinx-tribes-v2`, `sphinx-bot`, `sphinx-builtin-bots`) are published amd64-only, so on Apple silicon the harness needs them forced to `linux/x86_64`; not relevant on the amd64 swarm hosts.
- `cargo run --bin sphinx` does not load `.env`, and `get_environment()` defaults to Cloud, so a local run needs `RUST_ENV=development` on the command line to avoid the awslogs driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)