### PR TITLE
Extend Fluentd log config for cache continuity and buffer bounding, document env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,27 @@
 RUST_ENV=development
+# Set RUST_ENV=fluentd to route managed-container logs through the Fluent Bit
+# sidecar (rate-limited CloudWatch). Default remains development/local.
+
+# Docker fluentd driver → sidecar. Default localhost:24224 if unset.
+# FLUENTD_ADDRESS=localhost:24224
+# Leave FLUENTD_TAG at its default ({{.Name}}). The Lua rate limiter keys on
+# the daemon-set container_name field; a static tag is unsupported for
+# per-container throttling.
+# FLUENTD_TAG={{.Name}}
+
+# Per-container records-per-interval cap (Fluent Bit Lua filter).
+# FLUENTBIT_RATE_LIMIT_DEFAULT=100
+# Optional overrides, format name=integer,name2=integer2
+# FLUENTBIT_RATE_LIMIT_OVERRIDES=neo4j=500,jarvis=200
+
+# Docker fluentd in-memory buffer bound (bytes) if the sidecar is down. Default 1048576 (1MiB).
+# FLUENTD_BUFFER_LIMIT=1048576
+
+# CloudWatch group is /swarms/{SWARM_NUMBER} (see SWARM_NUMBER below).
+# AWS credentials: prefer IMDS/instance-role. Static keys only from a secret
+# store — never commit real values.
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
 
 # Port where Swarm is going to be running on
 ROCKET_PORT=8888

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -94,10 +94,19 @@ fn local_log_config(swarm_id: &str) -> Option<HostConfigLogConfig> {
                 .unwrap_or_else(|_| "localhost:24224".to_string());
             let tag = env::var("FLUENTD_TAG")
                 .unwrap_or_else(|_| "{{.Name}}".to_string());
+            // Docker fluentd-buffer-limit is bytes (Atoi); default matches
+            // the daemon's 1MiB so a sidecar outage cannot grow unbounded.
+            let buffer_limit = env::var("FLUENTD_BUFFER_LIMIT")
+                .unwrap_or_else(|_| "1048576".to_string());
 
             h.insert("fluentd-address".to_string(), address);
             h.insert("tag".to_string(), tag);
             h.insert("fluentd-async".to_string(), "true".to_string());
+            h.insert("fluentd-buffer-limit".to_string(), buffer_limit);
+            // Same dual-logging cache as Cloud so docker.logs() (in-app
+            // viewers) still returns output for the remote fluentd driver.
+            h.insert("cache-max-size".to_string(), "10m".to_string());
+            h.insert("cache-max-file".to_string(), "3".to_string());
 
             Some(HostConfigLogConfig {
                 typ: Some("fluentd".to_string()),
@@ -122,6 +131,7 @@ mod tests {
         env::set_var("RUST_ENV", "fluentd");
         env::set_var("FLUENTD_ADDRESS", "vector.example.com:24224");
         env::set_var("FLUENTD_TAG", "myapp");
+        env::set_var("FLUENTD_BUFFER_LIMIT", "8388608");
 
         let config = local_log_config("test-swarm").unwrap();
         assert_eq!(config.typ, Some("fluentd".to_string()));
@@ -129,10 +139,14 @@ mod tests {
         assert_eq!(cfg.get("fluentd-address").unwrap(), "vector.example.com:24224");
         assert_eq!(cfg.get("tag").unwrap(), "myapp");
         assert_eq!(cfg.get("fluentd-async").unwrap(), "true");
+        assert_eq!(cfg.get("fluentd-buffer-limit").unwrap(), "8388608");
+        assert_eq!(cfg.get("cache-max-size").unwrap(), "10m");
+        assert_eq!(cfg.get("cache-max-file").unwrap(), "3");
 
         env::remove_var("RUST_ENV");
         env::remove_var("FLUENTD_ADDRESS");
         env::remove_var("FLUENTD_TAG");
+        env::remove_var("FLUENTD_BUFFER_LIMIT");
     }
 
     #[test]
@@ -141,6 +155,7 @@ mod tests {
         env::set_var("RUST_ENV", "fluentd");
         env::remove_var("FLUENTD_ADDRESS");
         env::remove_var("FLUENTD_TAG");
+        env::remove_var("FLUENTD_BUFFER_LIMIT");
 
         let config = local_log_config("test-swarm").unwrap();
         assert_eq!(config.typ, Some("fluentd".to_string()));
@@ -148,6 +163,9 @@ mod tests {
         assert_eq!(cfg.get("fluentd-address").unwrap(), "localhost:24224");
         assert_eq!(cfg.get("tag").unwrap(), "{{.Name}}");
         assert_eq!(cfg.get("fluentd-async").unwrap(), "true");
+        assert_eq!(cfg.get("fluentd-buffer-limit").unwrap(), "1048576");
+        assert_eq!(cfg.get("cache-max-size").unwrap(), "10m");
+        assert_eq!(cfg.get("cache-max-file").unwrap(), "3");
 
         env::remove_var("RUST_ENV");
     }


### PR DESCRIPTION
## Summary
- Extend Fluentd log config with `fluentd-buffer-limit` (default 1MiB) so sidecar outages cannot grow the in-memory buffer unbounded.
- Enable Docker log cache (`cache-max-size` / `cache-max-file`) so `docker.logs()` still works with the remote fluentd driver.
- Document Fluentd/Fluent Bit related env vars in `.env.example`.

## Test plan
- [ ] Confirm unit tests in `src/utils.rs` pass for custom and default Fluentd log config.
- [ ] Verify `.env.example` documents FLUENTD_* and FLUENTBIT_* vars without changing runtime defaults.