### PR TITLE
Move Docker base images from bullseye (EOL) to bookworm

### DIFF
--- a/src/bin/stack/Dockerfile
+++ b/src/bin/stack/Dockerfile
@@ -1,5 +1,5 @@
 # Rust as the base image
-FROM rust:1.88-slim-bullseye as build
+FROM rust:1.88-slim-bookworm AS build
 
 # Create a new empty shell project
 # RUN USER=root cargo new --lib sphinx-swarm
@@ -30,8 +30,8 @@ RUN cargo build --release --bin stack
 
 # The final base image
 # FROM debian:buster-slim
-# FROM debian:bullseye-slim
-FROM debian:11-slim
+# FROM debian:bookworm-slim
+FROM debian:12-slim
 
 # get root CA certs
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates 

--- a/src/bin/super/Dockerfile
+++ b/src/bin/super/Dockerfile
@@ -1,6 +1,6 @@
 # --- Stage 1: Install cargo-chef using nightly (required for edition2024)
 # Use a nightly tag to support the unstable edition2024 feature
-FROM rustlang/rust:nightly-bullseye AS chef
+FROM rustlang/rust:nightly-bookworm AS chef
 RUN cargo +nightly install cargo-chef --locked
 WORKDIR /sphinx-swarm
 
@@ -29,7 +29,7 @@ COPY . .
 RUN cargo +nightly build --release --bin super
 
 # --- Stage 4: Runtime (No change needed here)
-FROM debian:11-slim
+FROM debian:12-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Why

CI is red on master: https://github.com/stakwork/sphinx-swarm/actions/runs/34185548963

Debian 11 (bullseye) reached end-of-life on 2026-08-31. The `bullseye-security` Release file has now passed its Valid-Until date and is no longer being re-signed, so `apt-get update` exits non-zero on any bullseye image:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 6h 50min 22s).
```

Both the stack and superadmin builds fail in the runtime stage, and the build stages would fail the same way once they reach their own `apt-get update`.

## What

Every stage in both Dockerfiles moves to bookworm (Debian 12, security support through 2028):

- `src/bin/stack/Dockerfile`: `rust:1.88-slim-bookworm` builder, `debian:12-slim` runtime. Also `as` -> `AS` to clear the FromAsCasing warning.
- `src/bin/super/Dockerfile`: `rustlang/rust:nightly-bookworm` chef stage, `debian:12-slim` runtime.

Build and runtime stages move together on purpose: a binary compiled on bookworm links against glibc 2.36 and needs a bookworm-or-newer runtime.

## Verified

- Both new tags exist on Docker Hub.
- `apt-get update && apt-get install ca-certificates` succeeds in `debian:12-slim` locally, while `debian:11-slim` still reproduces the exact CI error.