### PR TITLE
Generated with Hive: Add lifetime per-container byte and record totals with throttled JSON dump to rate_limit.lua

### DIFF
--- a/fluent-bit/rate_limit.lua
+++ b/fluent-bit/rate_limit.lua
@@ -12,11 +12,23 @@
 -- Keyed on the Docker-daemon-set `container_name` record field (fallback:
 -- fluentd tag). Override maps are parsed with a strict delimiter split —
 -- never load / loadstring / dofile on env content.
+--
+-- Lifetime totals (total_count / total_bytes) accumulate accepted traffic
+-- only and survive hourly window reset. They persist until Fluent Bit
+-- restarts OR that key is LRU-evicted when FLUENTBIT_RATE_LIMIT_MAX_KEYS
+-- (default 256) is hit — eviction deletes the whole per-key entry, including
+-- lifetime totals. Do not lift max_keys to retain totals; healthy swarms
+-- have far fewer than 256 containers. Totals are snapshotted to
+-- /var/log/flb-storage/container_stats.json (storage.path volume) at most
+-- once per second. The dump is removed on script load so a volume-persisted
+-- file cannot outlive this process.
 
 local DEFAULT_CAP = 500000 -- 500k events / hour
 local DEFAULT_BYTE_CAP = 67108864 -- 64 MiB / hour (~1.55 GiB/day)
 local DEFAULT_INTERVAL = 3600 -- hourly window
 local DEFAULT_MAX_KEYS = 256
+local DEFAULT_STATS_PATH = "/var/log/flb-storage/container_stats.json"
+local DUMP_INTERVAL = 1 -- at most once per second
 
 local getenv = os.getenv
 local printer = print
@@ -28,6 +40,9 @@ local max_keys = DEFAULT_MAX_KEYS
 local overrides = {}
 local byte_overrides = {}
 local state = {}
+local stats_path = DEFAULT_STATS_PATH
+local last_dump = nil
+local dump_dirty = false
 
 local function trim(s)
   return (s:gsub("^%s+", ""):gsub("%s+$", ""))
@@ -40,6 +55,23 @@ local function sanitize(s, max_len)
   if #s > max_len then
     s = s:sub(1, max_len) .. "..."
   end
+  return s
+end
+
+-- JSON string encoder for dump output. Do not reuse sanitize(): that helper
+-- truncates at 128 bytes and is only for [rate_limit] printer lines.
+local function json_escape(s)
+  s = tostring(s or "")
+  s = s:gsub("\\", "\\\\")
+  s = s:gsub('"', '\\"')
+  s = s:gsub("\b", "\\b")
+  s = s:gsub("\f", "\\f")
+  s = s:gsub("\n", "\\n")
+  s = s:gsub("\r", "\\r")
+  s = s:gsub("\t", "\\t")
+  s = s:gsub("[%z\1-\31]", function(c)
+    return string.format("\\u%04x", string.byte(c))
+  end)
   return s
 end
 
@@ -118,6 +150,8 @@ end
 
 local function reset_state()
   state = {}
+  last_dump = nil
+  dump_dirty = false
 end
 
 local function to_seconds(timestamp)
@@ -167,6 +201,8 @@ local function ensure_key(key, now)
   st = {
     count = 0,
     bytes = 0,
+    total_count = 0,
+    total_bytes = 0,
     window = window_id(now),
     notified = false,
     last_seen = now,
@@ -234,6 +270,90 @@ local function record_key(tag, record)
   return "unknown"
 end
 
+local function stats_for(key)
+  local st = state[key]
+  if not st then
+    return nil
+  end
+  return {
+    count = st.count,
+    bytes = st.bytes,
+    total_count = st.total_count or 0,
+    total_bytes = st.total_bytes or 0,
+    window = st.window,
+  }
+end
+
+-- Pure encoder: lifetime totals only, never log bodies. No cjson.
+local function encode_stats()
+  local names = {}
+  for k in pairs(state) do
+    names[#names + 1] = k
+  end
+  table.sort(names)
+  local parts = {}
+  for _, k in ipairs(names) do
+    local st = state[k]
+    parts[#parts + 1] = string.format(
+      '{"container_name":"%s","input_bytes":%d,"input_records":%d}',
+      json_escape(k),
+      st.total_bytes or 0,
+      st.total_count or 0
+    )
+  end
+  return '{"containers":[' .. table.concat(parts, ",") .. "]}"
+end
+
+local function write_dump_file(path, json)
+  local tmp = path .. ".tmp"
+  local f, err = io.open(tmp, "w")
+  if not f then
+    error(err or "io.open failed")
+  end
+  local ok, werr = f:write(json)
+  f:close()
+  if not ok then
+    error(werr or "write failed")
+  end
+  local renamed, rerr = os.rename(tmp, path)
+  if not renamed then
+    error(rerr or "os.rename failed")
+  end
+end
+
+-- Throttled atomic dump. I/O is pcall'd so a failure never throws to the
+-- caller; in-memory counters stay intact. Single global last_dump (not
+-- per-key) so max_keys=256 cannot produce hundreds of writes per second.
+-- last_dump advances on any attempt so a missing volume cannot retry I/O
+-- on every record; dump_dirty stays set until a write succeeds.
+local function dump_stats(path, now)
+  if not dump_dirty then
+    return false
+  end
+  now = now or os.time()
+  if last_dump ~= nil and (now - last_dump) < DUMP_INTERVAL then
+    return false
+  end
+  path = path or stats_path
+  local json = encode_stats()
+  -- Advance the throttle before I/O so a throw cannot skip it.
+  last_dump = now
+  local ok = pcall(write_dump_file, path, json)
+  if ok then
+    dump_dirty = false
+  end
+  return ok
+end
+
+local function maybe_dump(now)
+  pcall(dump_stats, stats_path, now)
+end
+
+local function clear_stale_dump(path)
+  os.remove(path)
+  os.remove(path .. ".tmp")
+end
+
 function rate_limit(tag, timestamp, record)
   local now = to_seconds(timestamp)
   local key = record_key(tag, record)
@@ -248,6 +368,7 @@ function rate_limit(tag, timestamp, record)
     st.count = 0
     st.bytes = 0
     st.notified = false
+    -- total_count / total_bytes survive window rollover.
   end
 
   -- Byte cap is primary (cost). Record cap is a secondary guard.
@@ -268,17 +389,23 @@ function rate_limit(tag, timestamp, record)
         )
       )
     end
+    maybe_dump(now)
     return -1, timestamp, nil
   end
 
   st.count = st.count + 1
   st.bytes = st.bytes + nbytes
+  st.total_count = (st.total_count or 0) + 1
+  st.total_bytes = (st.total_bytes or 0) + nbytes
+  dump_dirty = true
+  maybe_dump(now)
   -- 1 = use this record (applies the leading-slash normalization).
   -- 0 would discard record mutations and keep Docker's "/name".
   return 1, timestamp, record
 end
 
 reload_config()
+pcall(clear_stale_dump, DEFAULT_STATS_PATH)
 
 -- Test seam. Fluent Bit only requires the global `rate_limit` callback;
 -- this table is unused in production.
@@ -296,6 +423,12 @@ RateLimit = {
   cap_for = cap_for,
   byte_cap_for = byte_cap_for,
   record_log_bytes = record_log_bytes,
+  stats_for = stats_for,
+  encode_stats = encode_stats,
+  dump_stats = dump_stats,
+  set_stats_path = function(p)
+    stats_path = p or DEFAULT_STATS_PATH
+  end,
   set_env = function(tbl)
     if tbl == nil then
       getenv = os.getenv

--- a/fluent-bit/tests/rate_limit_spec.lua
+++ b/fluent-bit/tests/rate_limit_spec.lua
@@ -142,11 +142,14 @@ describe("rate_limit filter", function()
       notices[#notices + 1] = msg
     end)
     RateLimit.set_env(default_env())
+    -- Existing specs must not write the production dump path.
+    RateLimit.set_stats_path("/no/such/dir/container_stats.json")
   end)
 
   after_each(function()
     RateLimit.set_printer(nil)
     RateLimit.set_env(nil)
+    RateLimit.set_stats_path(nil)
   end)
 
   it("passes records under the cap through", function()
@@ -380,5 +383,176 @@ describe("rate_limit filter", function()
     local code = rate_limit("tag", ts(100), { container_name = "nolog" })
     assert.are.equal(PASS, code)
     assert.are.equal(0, RateLimit.record_log_bytes({ container_name = "nolog" }))
+  end)
+end)
+
+local function decode_containers(json)
+  assert.is_not_nil(json:match('^{"containers":%[.*%]}$'), "unexpected dump shape: " .. json)
+  local inner = json:match('^{"containers":%[(.*)%]}$')
+  local items = {}
+  for obj in inner:gmatch("{.-}") do
+    local name = obj:match('"container_name":"(.-)"')
+    local bytes = tonumber(obj:match('"input_bytes":(%d+)'))
+    local records = tonumber(obj:match('"input_records":(%d+)'))
+    items[#items + 1] = {
+      container_name = name,
+      input_bytes = bytes,
+      input_records = records,
+    }
+    items[name] = items[#items]
+  end
+  return items
+end
+
+describe("lifetime totals and stats dump", function()
+  local notices
+  local tmpdir
+
+  before_each(function()
+    notices = {}
+    RateLimit.set_printer(function(msg)
+      notices[#notices + 1] = msg
+    end)
+    RateLimit.set_env(default_env())
+    tmpdir = os.tmpname()
+    os.remove(tmpdir)
+    os.execute("mkdir -p " .. tmpdir)
+    RateLimit.set_stats_path(tmpdir .. "/container_stats.json")
+  end)
+
+  after_each(function()
+    RateLimit.set_printer(nil)
+    RateLimit.set_env(nil)
+    RateLimit.set_stats_path(nil)
+    if tmpdir then
+      os.execute("rm -rf " .. tmpdir)
+    end
+  end)
+
+  it("keeps lifetime totals across a window rollover that resets the hourly counters", function()
+    rate_limit("tag", ts(100), rec("alpha", "hello"))
+    rate_limit("tag", ts(100), rec("alpha", "world"))
+    local before = RateLimit.stats_for("alpha")
+    assert.are.equal(2, before.count)
+    assert.are.equal(10, before.bytes)
+    assert.are.equal(2, before.total_count)
+    assert.are.equal(10, before.total_bytes)
+
+    -- interval=10, so t=110 is the next window; hourly counters reset.
+    rate_limit("tag", ts(110), rec("alpha", "again"))
+    local after = RateLimit.stats_for("alpha")
+    assert.are.equal(1, after.count)
+    assert.are.equal(5, after.bytes)
+    assert.are.equal(3, after.total_count)
+    assert.are.equal(15, after.total_bytes)
+  end)
+
+  it("does not increment lifetime totals on throttle", function()
+    collect_codes("alpha", 5, 100, "hello")
+    local st = RateLimit.stats_for("alpha")
+    assert.are.equal(3, st.count)
+    assert.are.equal(3, st.total_count)
+    assert.are.equal(15, st.total_bytes)
+  end)
+
+  it("keys lifetime totals by the slash-stripped container_name", function()
+    rate_limit("tag", ts(100), rec("/jarvis", "hello"))
+    assert.is_true(RateLimit.has_key("jarvis"))
+    assert.is_false(RateLimit.has_key("/jarvis"))
+    local json = RateLimit.encode_stats()
+    local items = decode_containers(json)
+    assert.is_nil(items["/jarvis"])
+    assert.are.equal("jarvis", items["jarvis"].container_name)
+    assert.are.equal(5, items["jarvis"].input_bytes)
+    assert.are.equal(1, items["jarvis"].input_records)
+  end)
+
+  it("encode_stats produces the containers dump shape for known values", function()
+    rate_limit("tag", ts(100), rec("jarvis", "hello"))
+    rate_limit("tag", ts(100), rec("boltwall", "abcd"))
+    rate_limit("tag", ts(100), rec("boltwall", "ef"))
+    local json = RateLimit.encode_stats()
+    local items = decode_containers(json)
+    assert.are.equal(2, #items)
+    assert.are.equal(5, items["jarvis"].input_bytes)
+    assert.are.equal(1, items["jarvis"].input_records)
+    assert.are.equal(6, items["boltwall"].input_bytes)
+    assert.are.equal(2, items["boltwall"].input_records)
+  end)
+
+  it("encode_stats after reset produces an empty containers list", function()
+    rate_limit("tag", ts(100), rec("alpha", "hello"))
+    RateLimit.reset()
+    assert.are.equal('{"containers":[]}', RateLimit.encode_stats())
+  end)
+
+  it("escapes quotes and backslashes in container names as valid JSON", function()
+    rate_limit("tag", ts(100), rec('a"b\\c', "hello"))
+    local json = RateLimit.encode_stats()
+    assert.is_not_nil(json:match('"container_name":"a\\"b\\\\c"'), json)
+    assert.is_not_nil(json:match('"input_bytes":5'))
+    assert.is_not_nil(json:match('"input_records":1'))
+    assert.is_not_nil(json:match('^{"containers":%[.*%]}$'))
+  end)
+
+  it("does not throw out of rate_limit when dump I/O fails", function()
+    RateLimit.set_stats_path("/no/such/dir/container_stats.json")
+    local ok, code, timestamp, out = pcall(
+      rate_limit,
+      "tag",
+      ts(100),
+      rec("alpha", "hello")
+    )
+    assert.is_true(ok)
+    assert.are.equal(PASS, code)
+    assert.are.equal("hello", out.log)
+    assert.are.equal(100, timestamp.sec)
+    local st = RateLimit.stats_for("alpha")
+    assert.are.equal(1, st.total_count)
+    assert.are.equal(5, st.total_bytes)
+  end)
+
+  it("throttles dumps globally so rapid calls in the same second write once", function()
+    local path = tmpdir .. "/container_stats.json"
+    RateLimit.set_stats_path(path)
+    rate_limit("tag", ts(100), rec("alpha", "hello"))
+    local first = assert(io.open(path, "r"))
+    local first_json = first:read("*a")
+    first:close()
+    assert.is_not_nil(first_json:match('"alpha"'))
+
+    -- Same-second follow-up must not rewrite even though totals changed.
+    os.remove(path)
+    rate_limit("tag", ts(100), rec("alpha", "world"))
+    local missing = io.open(path, "r")
+    assert.is_nil(missing)
+
+    -- Next second is allowed to write again.
+    rate_limit("tag", ts(101), rec("alpha", "again"))
+    local second = assert(io.open(path, "r"))
+    local second_json = second:read("*a")
+    second:close()
+    local items = decode_containers(second_json)
+    assert.are.equal(3, items["alpha"].input_records)
+  end)
+
+  it("omits LRU-evicted keys from the next encode_stats dump", function()
+    RateLimit.set_env(default_env({
+      FLUENTBIT_RATE_LIMIT_DEFAULT = "1",
+      FLUENTBIT_RATE_LIMIT_MAX_KEYS = "3",
+    }))
+    rate_limit("t", ts(100), rec("k1", "aaaa"))
+    rate_limit("t", ts(101), rec("k2", "bbbb"))
+    rate_limit("t", ts(102), rec("k3", "cccc"))
+    local before = decode_containers(RateLimit.encode_stats())
+    assert.is_not_nil(before["k1"])
+    rate_limit("t", ts(103), rec("k4", "dddd"))
+    assert.is_false(RateLimit.has_key("k1"))
+    local after = decode_containers(RateLimit.encode_stats())
+    assert.is_nil(after["k1"])
+    assert.is_not_nil(after["k2"])
+    assert.is_not_nil(after["k3"])
+    assert.is_not_nil(after["k4"])
+    assert.are.equal(3, #after)
   end)
 end)


### PR DESCRIPTION
Add lifetime per-container byte and record totals with throttled JSON dump to rate_limit.lua.