### PR TITLE
bifrost: enforce_macaroons config field

### DIFF
--- a/src/images/bifrost.rs
+++ b/src/images/bifrost.rs
@@ -26,6 +26,17 @@ pub struct BifrostImage {
     pub admin_user: String,
     #[serde(default = "default_admin_password")]
     pub admin_password: String,
+    // Overrides the gateway plugin's baked-in `enforce_macaroons`
+    // (gateway/data/config.json, re-seeded on every boot). `None`
+    // (the default, and what pre-existing persisted state loads as)
+    // emits no env var, so the image's config.json value stands
+    // (false: shadow mode — verify + log, never reject). `Some(true)`
+    // ⇒ missing/invalid macaroons 401. Flipping this on is
+    // all-or-nothing per swarm: every caller must already present a
+    // valid macaroon. `skip_serializing_if` keeps the persisted JSON
+    // free of the key when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enforce_macaroons: Option<bool>,
 }
 
 fn default_admin_user() -> String {
@@ -55,6 +66,7 @@ impl BifrostImage {
             // exposed to Hive via /_plugin/admin-credentials so workspace
             // admins can copy-paste it into the dashboard login.
             admin_password: default_admin_password(),
+            enforce_macaroons: None,
         }
     }
     pub fn links(&mut self, links: Vec<&str>) {
@@ -181,6 +193,15 @@ pub fn bifrost(
             neo4j.http_port,
         ));
         env.push(format!("NEO4J_PASSWORD={}", neo4j.password));
+    }
+
+    // Macaroon enforcement override. The gateway reads
+    // BIFROST_PLUGIN_ENFORCE_MACAROONS at plugin Init (truthy
+    // 1/true/yes/on, falsy 0/false/no/off; unset ⇒ config.json). This
+    // is swarm config, not a host secret, so it comes from the
+    // persisted image struct rather than getenv().
+    if let Some(enforce) = img.enforce_macaroons {
+        env.push(format!("BIFROST_PLUGIN_ENFORCE_MACAROONS={}", enforce));
     }
 
     // Provider API keys referenced by Bifrost's config.json via env.<NAME>.
@@ -448,5 +469,69 @@ mod tests {
         // Absent neo4j link ⇒ no NEO4J_* env ⇒ the plugin's agent-catalog
         // endpoints return 503 (every agent shows "traffic only").
         assert!(!env.iter().any(|e| e.starts_with("NEO4J_")));
+    }
+
+    #[test]
+    fn test_bifrost_enforce_macaroons_emitted_when_set() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        std::env::remove_var("OPENAI_API_KEY");
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("OPENROUTER_API_KEY");
+        std::env::remove_var("GOOGLE_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let mut img = test_bifrost_image();
+        img.enforce_macaroons = Some(true);
+        let config = bifrost(&img, &None, &None, &None);
+        let env = config.env.unwrap();
+        assert!(env.contains(&"BIFROST_PLUGIN_ENFORCE_MACAROONS=true".to_string()));
+
+        // Explicit false is still emitted: it pins shadow mode even if
+        // a future image flips the baked-in config.json default.
+        img.enforce_macaroons = Some(false);
+        let config = bifrost(&img, &None, &None, &None);
+        let env = config.env.unwrap();
+        assert!(env.contains(&"BIFROST_PLUGIN_ENFORCE_MACAROONS=false".to_string()));
+    }
+
+    #[test]
+    fn test_bifrost_no_enforce_macaroons_when_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        std::env::remove_var("OPENAI_API_KEY");
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("OPENROUTER_API_KEY");
+        std::env::remove_var("GOOGLE_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let img = test_bifrost_image();
+        assert_eq!(img.enforce_macaroons, None);
+        let config = bifrost(&img, &None, &None, &None);
+        let env = config.env.unwrap();
+
+        // None ⇒ no env var ⇒ the image's config.json value stands.
+        assert!(!env
+            .iter()
+            .any(|e| e.starts_with("BIFROST_PLUGIN_ENFORCE_MACAROONS=")));
+    }
+
+    #[test]
+    fn test_bifrost_enforce_macaroons_serde_round_trip() {
+        // Pre-existing persisted state has no `enforce_macaroons` key
+        // and must still load (as None). When None, the key must not
+        // be written back so the persisted JSON stays unchanged.
+        let img = test_bifrost_image();
+        let json = serde_json::to_string(&img).unwrap();
+        assert!(!json.contains("enforce_macaroons"));
+        let back: BifrostImage = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.enforce_macaroons, None);
+
+        let mut img = test_bifrost_image();
+        img.enforce_macaroons = Some(true);
+        let json = serde_json::to_string(&img).unwrap();
+        assert!(json.contains("\"enforce_macaroons\":true"));
+        let back: BifrostImage = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.enforce_macaroons, Some(true));
     }
 }


### PR DESCRIPTION
Wires stakwork/stakgraph#1674's `BIFROST_PLUGIN_ENFORCE_MACAROONS` override into the swarm's bifrost image.

Modeled as a persisted config field on `BifrostImage` (not a host env passthrough): swarm env is for secrets, the struct is for config.

- `enforce_macaroons: Option<bool>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Existing persisted state loads as `None`; the key is never written back when unset.
- `None` ⇒ no env var ⇒ the image's baked-in `config.json` value stands (false, shadow mode). `Some(true)` ⇒ missing/invalid macaroons 401.
- Flipping it on is all-or-nothing per swarm: every caller must already present a valid macaroon.

Tests: emitted when set (true and false), absent when unset, serde round-trip. `cargo test --lib images::bifrost` 13/13.