### PR TITLE
Fix SSL cert renewal: surface restarter errors, read real cert expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1327,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2465,6 +2524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +2623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3291,6 +3369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +3986,7 @@ dependencies = [
  "tonic_lnd",
  "url",
  "walkdir",
+ "x509-parser",
  "zip",
 ]
 
@@ -5013,6 +5101,23 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde_yaml = "0.9"
 tokio-cron-scheduler = "*"
 sphinx-auther = { git = "https://github.com/stakwork/sphinx-rs.git", branch = "master" }
 zip = "0.6.5"
+x509-parser = "0.18"
 tokio = { version = "1", features = ["full"] }
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.38.0"

--- a/restarter.js
+++ b/restarter.js
@@ -17,7 +17,7 @@ function is2b() {
 }
 
 http
-  .createServer(async (req, res) => {
+  .createServer(withErrorResponse(async (req, res) => {
     if (req.method === "OPTIONS") {
       return end(res, 200, "");
     }
@@ -124,9 +124,9 @@ http
           console.log(stdout);
           console.log("error:", stderr);
           respond(res, { ok: true, message: stdout, error: stderr });
-        } catch (error) {
+        } catch (e) {
           console.log("error:", e);
-          failure(res, e.message);
+          failure(res, execErrorMessage(e));
         }
       }
       if (url === "/upload-cert") {
@@ -168,9 +168,9 @@ http
             message: message.join(","),
             error: errMsg.join(","),
           });
-        } catch (error) {
+        } catch (e) {
           console.log("error:", e);
-          failure(res, e.message);
+          failure(res, execErrorMessage(e));
         }
       }
       if (url === "/nuke") {
@@ -246,7 +246,7 @@ http
           `docker stop load_balancer`,
           `docker rm load_balancer`,
           `sudo rm -rf /home/admin/certs`,
-          `sudo mkdir -p /home/admins/certs`,
+          `sudo mkdir -p /home/admin/certs`,
           `sudo unzip -o -j /home/admin/data.zip -d /home/admin/certs/`,
           `sudo chown admin:admin /home/admin/certs/*`,
           `sudo chmod 644 /home/admin/certs/sphinx.chat.crt`,
@@ -267,7 +267,7 @@ http
         }
       }
     }
-  })
+  }))
   .listen(port, hostname, () => {
     console.log(`Server running at http://${hostname}:${port}/`);
   });
@@ -277,7 +277,21 @@ function respond(res, response) {
 }
 
 function failure(res, err_msg) {
-  end(res, 401, JSON.stringify({ error: err_msg }));
+  end(res, 401, JSON.stringify({ ok: false, error: err_msg }));
+}
+
+// exec errors carry the command's stderr (e.g. certbot's actual failure reason)
+function execErrorMessage(e) {
+  return (e && e.stderr && e.stderr.trim()) || (e && e.message) || String(e);
+}
+
+// always send a response, so a thrown error doesn't leave the caller hanging until it times out
+function withErrorResponse(handler) {
+  return (req, res) =>
+    handler(req, res).catch((e) => {
+      console.log("error:", e);
+      if (!res.headersSent) failure(res, execErrorMessage(e));
+    });
 }
 
 function readBody(req) {

--- a/src/bin/super/service/ssl_cert/handle_renew_cert.rs
+++ b/src/bin/super/service/ssl_cert/handle_renew_cert.rs
@@ -1,3 +1,4 @@
+use std::io::{Cursor, Read};
 use std::time::Duration;
 
 use anyhow::{anyhow, Error, Result};
@@ -6,6 +7,7 @@ use aws_config::Region;
 use aws_sdk_s3::Client;
 use chrono::{DateTime, Utc};
 use sphinx_swarm::utils::getenv;
+use x509_parser::pem::parse_x509_pem;
 
 use crate::{
     cmd::{SllCertExpiryDaysResponse, SuperRestarterResponse, SuperSwarmResponse},
@@ -25,9 +27,23 @@ pub async fn handle_renew_ssl_cert() -> Result<()> {
 
     log::info!("Renew cert response: {:#?}", renew_cert_res);
 
+    if !renew_cert_res.ok {
+        return Err(anyhow!(
+            "Failed to renew cert: {}",
+            renew_cert_res.error.unwrap_or_default()
+        ));
+    }
+
     let upload_cert_res = upload_cert_to_s3().await?;
 
     log::info!("Upload cert response: {:#?}", upload_cert_res);
+
+    if !upload_cert_res.ok {
+        return Err(anyhow!(
+            "Failed to upload cert to s3: {}",
+            upload_cert_res.error.unwrap_or_default()
+        ));
+    }
     Ok(())
 }
 
@@ -42,24 +58,38 @@ pub async fn get_cert_days_left() -> Result<i64, Error> {
     let config = aws_config::from_env().region(region_provider).load().await;
     let client = Client::new(&config);
 
-    let resp = client.head_object().bucket(bucket).key(key).send().await?;
+    let resp = client.get_object().bucket(bucket).key(key).send().await?;
+    let zip_bytes = resp.body.collect().await?.into_bytes();
 
-    // get last date modified
-    if let None = resp.last_modified() {
-        return Err(anyhow!("Unable to get last date modified from s3 bucket"));
-    }
+    // read the expiry from the cert itself, not the upload date
+    let not_after = cert_not_after(&zip_bytes)?;
 
-    let last_modified = resp.last_modified().unwrap();
-    let now = Utc::now();
+    let diff = not_after.signed_duration_since(Utc::now());
 
-    let last_modified_chrono = DateTime::<Utc>::from_timestamp(last_modified.secs(), 0)
-        .ok_or_else(|| anyhow!("Failed to convert last_modified to chrono::DateTime"))?;
+    Ok(diff.num_days())
+}
 
-    let diff = now.signed_duration_since(last_modified_chrono);
+fn cert_not_after(zip_bytes: &[u8]) -> Result<DateTime<Utc>, Error> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes))?;
 
-    let days_diff = diff.num_days();
+    let crt_name = archive
+        .file_names()
+        .find(|name| name.ends_with("sphinx.chat.crt"))
+        .map(|name| name.to_string())
+        .ok_or_else(|| anyhow!("sphinx.chat.crt not found in data.zip"))?;
 
-    Ok(90 - days_diff)
+    let mut pem_bytes = Vec::new();
+    archive.by_name(&crt_name)?.read_to_end(&mut pem_bytes)?;
+
+    // fullchain.pem: the first cert is the leaf
+    let (_, pem) =
+        parse_x509_pem(&pem_bytes).map_err(|e| anyhow!("Failed to parse cert pem: {:?}", e))?;
+    let cert = pem
+        .parse_x509()
+        .map_err(|e| anyhow!("Failed to parse x509 cert: {:?}", e))?;
+
+    DateTime::<Utc>::from_timestamp(cert.validity().not_after.timestamp(), 0)
+        .ok_or_else(|| anyhow!("Failed to convert cert expiry to chrono::DateTime"))
 }
 
 pub async fn renew_cert() -> Result<SuperRestarterResponse, Error> {
@@ -67,7 +97,8 @@ pub async fn renew_cert() -> Result<SuperRestarterResponse, Error> {
     let password = std::env::var("SUPER_ADMIN_UPDATER_PASSWORD").unwrap_or(String::new());
 
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(20))
+        // certbot's dns challenge can take well over 20s
+        .timeout(Duration::from_secs(180))
         .danger_accept_invalid_certs(true)
         .build()
         .expect("couldnt build renew cert reqwest client");


### PR DESCRIPTION
## Why

The `*.sphinx.chat` cert expired on Sep 11 and no alert fired. From Aug 29 on, the superadmin's nightly renewal failed every night:

1. The renewal job ran at 00:00 UTC. Let's Encrypt was overloaded then and returned `rateLimited :: Service busy; retry later`, so certbot failed.
2. The restarter's `catch (error)` block then referenced an undefined `e`. That threw a `ReferenceError`, so no response was ever sent.
3. The superadmin only logged `operation timed out` after 20s and skipped the upload. This repeated for 14 nights, until the Jun 14 cert expired.

A second problem: "days left" was computed as `90 - days since data.zip was uploaded to S3`, not from the cert itself.

The schedule was already moved off midnight on the superadmin (`SSL_CERT_RENEWAL_CRON_TIME=0 37 3 * * *`). This PR fixes the error handling and the expiry check.

## Changes

**restarter.js**
- `/renew-cert` and `/upload-cert`: fix the `catch (error)` / `e` mix-up. Failures now return the command's stderr, e.g. certbot's actual error.
- `failure()` now includes `ok: false`, so the superadmin's `SuperRestarterResponse` can parse error replies.
- The request handler is wrapped so an unexpected throw (e.g. malformed JSON) still sends a response instead of hanging the caller.
- Fix the `/home/admins/certs` typo in `/update-ssl-cert`.

**superadmin (`handle_renew_cert.rs`)**
- `get_cert_days_left` downloads `data.zip`, reads `sphinx.chat.crt`, and uses the leaf cert's `notAfter` (new `x509-parser` dependency). The superadmin UI's expiry display uses the same function.
- `ok: false` from renew or upload is now returned as an error, so it's logged at ERROR level. Upload no longer runs after a failed renewal.
- `/renew-cert` request timeout raised from 20s to 180s. A slow but successful certbot run no longer looks like a failure.

## Testing
- `cargo check --bin super` passes.
- Ran restarter.js locally: wrong password, not-superadmin and malformed JSON all return `{"ok":false,...}` immediately. Malformed JSON previously hung.
- Ran `cert_not_after` in a standalone crate against a test `data.zip` laid out like the real one (`home/admin/certs/sphinx.chat.crt`). The expiry matched `openssl x509 -enddate`.
- Not tested against the real S3 bucket or a real certbot failure.

## Deploy notes
- restarter.js is not deployed by CI. The pm2 process runs a copy on each host, and the superadmin box has an older one. Copy it over by hand and run `pm2 restart restarter`.
- The repo's restarter.js includes `/nuke`, which wipes all containers and volumes. Compare against the host's copy before replacing it on the superadmin box.
