### PR TITLE
CLN: cln-grpc 0.7.0, xpay/getroutes/xkeysend, 3-node --bin cln harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +168,12 @@ checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -608,7 +620,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
@@ -691,45 +703,43 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "itoa",
  "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower",
+ "serde_core",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
- "rustversion",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -760,6 +770,15 @@ name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
+name = "base58ck"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
+dependencies = [
+ "bitcoin_hashes 0.14.101",
+]
 
 [[package]]
 name = "base64"
@@ -830,9 +849,9 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-beta"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "binascii"
@@ -878,16 +897,29 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.31.2"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "base58ck",
+ "bech32 0.11.1",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.101",
+ "hex-conservative 0.2.3",
  "hex_lit",
- "secp256k1 0.28.2",
+ "secp256k1 0.29.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6712f9c6fd6785b3b270884e57c441c403dc5d7e19ca45368c97c7a1de3000ec"
+dependencies = [
+ "bitcoin-internals 0.6.0",
+ "hex-conservative 1.3.0",
  "serde",
 ]
 
@@ -896,7 +928,29 @@ name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
 dependencies = [
+ "bitcoin-consensus-encoding",
+]
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
+dependencies = [
+ "bitcoin-consensus-encoding",
  "serde",
 ]
 
@@ -924,8 +978,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.3",
  "serde",
 ]
 
@@ -1133,22 +1197,25 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45847bc5ed9f8a8e2202aea5511ed15ab0cd9989585a3187c850e93f3f5f5b81"
+checksum = "69b7edcedcc92344cac1aa910cfff455ca818168b5bf9175f3a7b8b0d3a20dfc"
 dependencies = [
  "anyhow",
- "bitcoin 0.31.2",
+ "bitcoin 0.32.102",
+ "cfg-if",
  "futures-core",
  "hex",
  "log",
- "prost 0.12.6",
+ "prost 0.14.4",
  "serde",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.12",
- "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -1546,9 +1613,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1565,6 +1632,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1741,6 +1814,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.5.0",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.12",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,6 +1846,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1812,6 +1913,24 @@ name = "hex-conservative"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3fef046dca3ca91ee1408a8c1b80ab777e80a4d308d1bf4e7adb3fcb047e08"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271e0d19bcb473b6675739a2b536076b24a082316cb5199ad918edce10c599e8"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"
@@ -1915,7 +2034,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1938,6 +2057,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.19",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1990,6 +2110,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2407,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-uninit"
@@ -2765,11 +2898,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset 0.4.2",
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
  "indexmap 2.5.0",
 ]
 
@@ -2912,12 +3046,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -2940,20 +3074,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "bytes",
  "heck 0.4.1",
  "itertools",
  "log",
  "multimap",
- "once_cell",
- "petgraph 0.6.5",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.87",
  "tempfile",
@@ -3000,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3023,11 +3157,31 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.12.6",
+ "prost 0.14.4",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.6.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -3165,7 +3319,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
@@ -3178,11 +3332,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3417,14 +3571,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "log",
+ "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.15",
  "subtle",
  "zeroize",
 ]
@@ -3436,7 +3591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -3451,19 +3606,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3477,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -3610,12 +3759,12 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "secp256k1-sys 0.9.2",
+ "secp256k1-sys 0.10.1",
  "serde",
 ]
 
@@ -3639,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -3982,7 +4131,7 @@ dependencies = [
  "tokio",
  "tokio-cron-scheduler",
  "tokio-util 0.7.12",
- "tonic 0.11.0",
+ "tonic 0.14.6",
  "tonic_lnd",
  "url",
  "walkdir",
@@ -4075,6 +4224,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -4302,12 +4457,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
+ "rustls 0.23.44",
  "tokio",
 ]
 
@@ -4396,11 +4550,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost 0.9.0",
@@ -4409,7 +4563,7 @@ dependencies = [
  "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.10",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4418,29 +4572,29 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-timeout",
+ "h2 0.4.19",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
+ "socket2 0.6.3",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.5",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4460,15 +4614,41 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.11.0"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.14.4",
+ "prost-types 0.14.4",
+ "quote",
+ "syn 2.0.87",
+ "tempfile",
+ "tonic-build 0.14.6",
 ]
 
 [[package]]
@@ -4479,7 +4659,7 @@ dependencies = [
  "hex",
  "prost 0.9.0",
  "rustls 0.19.1",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "tokio",
  "tonic 0.6.2",
@@ -4500,6 +4680,25 @@ dependencies = [
  "pin-project-lite",
  "rand",
  "slab",
+ "tokio",
+ "tokio-util 0.7.12",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 2.5.0",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util 0.7.12",
  "tower-layer",
@@ -4621,6 +4820,12 @@ dependencies = [
  "serde",
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ bcrypt = "0.13"
 sha2 = "0.10"
 hmac = "0.12"
 async-trait = "0.1.64"
-tonic = { version = "0.11", features = ["tls", "transport"] }
+tonic = { version = "0.14", features = ["tls-ring", "transport"] }
 # cln-grpc = { git = "https://github.com/stakwork/lightning", rev = "ba0d317e751ee04c59c2400ddff201cf29ab76aa" }
-cln-grpc = "0.3.0"
+cln-grpc = "0.7.0"
 serde_yaml = "0.9"
 tokio-cron-scheduler = "*"
 sphinx-auther = { git = "https://github.com/stakwork/sphinx-rs.git", branch = "master" }

--- a/src/bin/cln/mod.rs
+++ b/src/bin/cln/mod.rs
@@ -18,6 +18,7 @@ use tokio::sync::{mpsc, Mutex};
 const BTC: &str = "btc_1";
 const CLN1: &str = "cln_1";
 const CLN2: &str = "cln_2";
+const CLN3: &str = "cln_3";
 const LSS: &str = "lss_1";
 const JWT_KEY: &str = "e8int45s0pofgtye";
 const LND_1: &str = "lnd_1";
@@ -64,6 +65,9 @@ pub async fn main() -> Result<()> {
     }
     if !skip_setup {
         setup_cln_chans(&mut clients, &stack.nodes, CLN1, CLN2, BTC).await?;
+        // cln_1 -> cln_2 <- cln_3, so cln_1 has a 2-hop route to cln_3
+        setup_cln_chans(&mut clients, &stack.nodes, CLN3, CLN2, BTC).await?;
+        try_check_2_hops(&mut clients, CLN1, CLN3).await;
         if do_test_proxy() {
             setup_lnd_chans(&mut clients, &stack.nodes, CLN1, LND_1, BTC).await?;
         }
@@ -105,21 +109,34 @@ fn make_stack() -> Stack {
         internal_nodes.push(Image::Lss(lss));
     }
 
+    // same seeds (so same pubkeys) and dev mode as the v1 harness (src/bin/v1)
+
     // CLN1
     let v = "latest";
     let mut cln = ClnImage::new(CLN1, v, &network, "9735", "10009");
+    cln.set_dev();
+    cln.set_seed("2b".repeat(32));
     cln.plugins(cln_plugins.clone());
     cln.links(vec![BTC, LSS]);
     internal_nodes.push(Image::Cln(cln));
 
     // CLN2
     let mut cln2 = ClnImage::new(CLN2, v, &network, "9736", "10010");
+    cln2.set_dev();
+    cln2.set_seed("2c".repeat(32));
     cln2.links(vec![BTC]);
     internal_nodes.push(Image::Cln(cln2));
 
+    // CLN3
+    let mut cln3 = ClnImage::new(CLN3, v, &network, "9737", "10011");
+    cln3.set_dev();
+    cln3.set_seed("2d".repeat(32));
+    cln3.links(vec![BTC]);
+    internal_nodes.push(Image::Cln(cln3));
+
     if do_test_proxy() {
         let v = "v0.16.2-beta";
-        let mut lnd = LndImage::new(LND_1, v, &network, "10011", "9737");
+        let mut lnd = LndImage::new(LND_1, v, &network, "10012", "9738");
         lnd.http_port = Some("8881".to_string());
         lnd.links(vec![BTC]);
 

--- a/src/bin/v1/mod.rs
+++ b/src/bin/v1/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use rocket::tokio;
-use sphinx_swarm::config::{Clients, Node, Stack};
+use sphinx_swarm::config::{Node, Stack};
 use sphinx_swarm::dock::*;
 use sphinx_swarm::images::cln::ClnPlugin;
 use sphinx_swarm::images::{
@@ -8,7 +8,7 @@ use sphinx_swarm::images::{
     lnd::LndImage, mixer::MixerImage, tribes::TribesImage, Image,
 };
 use sphinx_swarm::rocket_utils::CmdRequest;
-use sphinx_swarm::setup::{get_pubkey_cln, mine_blocks, setup_cln_chans, setup_lnd_chans};
+use sphinx_swarm::setup::{mine_blocks, setup_cln_chans, setup_lnd_chans, try_check_2_hops};
 use sphinx_swarm::utils::domain;
 use sphinx_swarm::{builder, events, handler, logs, routes};
 use std::sync::Arc;
@@ -115,29 +115,8 @@ pub async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn try_check_2_hops(clients: &mut Clients, node1: &str, node3: &str) {
-    for i in 0..200 {
-        let res = check_2_hops(clients, node1, node3).await;
-        if res.is_ok() {
-            return;
-        }
-        log::info!("retrying get_route to CLN3: {}...", i);
-        sleep(2).await;
-    }
-}
-
 async fn sleep(secs: u64) {
     tokio::time::sleep(tokio::time::Duration::from_secs(secs)).await;
-}
-
-async fn check_2_hops(clients: &mut Clients, node1: &str, node3: &str) -> Result<()> {
-    let cln3_pubkey = get_pubkey_cln(clients, node3).await?;
-    let cln1 = clients.cln.get_mut(node1).unwrap();
-    let res = cln1.get_route(&cln3_pubkey, 1000).await?;
-    if res.route.len() < 2 {
-        return Err(anyhow::anyhow!("no route found"));
-    }
-    Ok(())
 }
 
 fn make_stack() -> Stack {

--- a/src/conn/cln/mod.rs
+++ b/src/conn/cln/mod.rs
@@ -234,50 +234,28 @@ impl ClnRPC {
         maxfeepercent: Option<f64>,
         exemptfee: Option<u64>,
         extratlvs: Option<HashMap<u64, Vec<u8>>>,
-    ) -> Result<pb::KeysendResponse> {
-        let id = hex::decode(id)?;
-        let mut req = pb::KeysendRequest {
-            destination: id,
+    ) -> Result<pb::XkeysendResponse> {
+        // xkeysend has no routehints (a hint would have to become an askrene layer)
+        if route_hint.is_some() {
+            return Err(anyhow!("route hints are not supported by xkeysend"));
+        }
+        let req = pb::XkeysendRequest {
+            destination: hex::decode(id)?,
             amount_msat: Some(amount(amt)),
+            maxfee: keysend_maxfee(amt, maxfeepercent, exemptfee).map(amount),
+            // TLV type number -> hex value
+            extratlvs: extratlvs
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), hex::encode(v)))
+                .collect(),
             ..Default::default()
         };
-        if let Some(mfp) = maxfeepercent {
-            req.maxfeepercent = Some(mfp);
-        }
-        if let Some(ef) = exemptfee {
-            req.exemptfee = Some(amount(ef));
-        }
-        if let Some(tlvs) = extratlvs {
-            let mut entries: Vec<pb::TlvEntry> = Vec::new();
-            for (k, value) in tlvs {
-                entries.push(pb::TlvEntry { r#type: k, value })
-            }
-            req.extratlvs = Some(pb::TlvStream { entries });
-        }
-        if let Some(rh) = route_hint {
-            if let Some(pos) = rh.chars().position(|c| c == ':') {
-                let (pk, scid_str) = rh.split_at(pos);
-                let mut scid_string = scid_str.to_string();
-                scid_string.remove(0); // drop the ":"
-                let mut routehints = pb::RoutehintList { hints: vec![] };
-                let mut hint1 = pb::Routehint { hops: vec![] };
-                let scid = scid_string.parse::<u64>()?;
-                let hop1 = pb::RouteHop {
-                    id: hex::decode(pk)?,
-                    scid: ShortChannelId(scid).to_string(),
-                    feebase: Some(amount(0)),
-                    ..Default::default()
-                };
-                hint1.hops.push(hop1);
-                routehints.hints.push(hint1);
-                req.routehints = Some(routehints);
-            }
-        }
-        log::info!("=======> CLN KEYSEND REQ: {:?}", req);
-        let response = match self.client.clone().key_send(req).await {
+        log::info!("=======> CLN XKEYSEND REQ: {:?}", req);
+        let response = match self.client.clone().xkeysend(req).await {
             Ok(res) => res,
             Err(err) => {
-                log::error!("Error executing keysend: {:?}", err.message());
+                log::error!("Error executing xkeysend: {:?}", err.message());
                 return Err(anyhow!(extract_cln_error_msg(err.message())));
             }
         };
@@ -306,12 +284,12 @@ impl ClnRPC {
         Ok(response.into_inner())
     }
 
-    pub async fn pay(&self, bolt11: &str) -> Result<pb::PayResponse> {
+    pub async fn pay(&self, bolt11: &str) -> Result<pb::XpayResponse> {
         let response = match self
             .client
             .clone()
-            .pay(pb::PayRequest {
-                bolt11: bolt11.to_string(),
+            .xpay(pb::XpayRequest {
+                invstring: bolt11.to_string(),
                 ..Default::default()
             })
             .await
@@ -432,14 +410,21 @@ impl ClnRPC {
         }
     }
 
-    pub async fn get_route(&self, dest: &str, amt_msat: u64) -> Result<pb::GetrouteResponse> {
-        let req = pb::GetrouteRequest {
-            id: hex::decode(dest)?,
+    /// One route to `dest` from this node (same layers and limits as the mixer).
+    pub async fn get_routes(&self, dest: &str, amt_msat: u64) -> Result<pb::GetroutesResponse> {
+        let req = pb::GetroutesRequest {
+            source: self.get_info().await?.id,
+            destination: hex::decode(dest)?,
             amount_msat: Some(pb::Amount { msat: amt_msat }),
-            riskfactor: 10,
+            layers: vec!["auto.localchans".to_string(), "auto.sourcefree".to_string()],
+            maxfee_msat: Some(pb::Amount {
+                msat: std::cmp::max(5_000, amt_msat / 100),
+            }),
+            final_cltv: 9,
+            maxparts: Some(1),
             ..Default::default()
         };
-        let response = match self.client.clone().get_route(req).await {
+        let response = match self.client.clone().get_routes(req).await {
             Ok(res) => res,
             Err(err) => {
                 log::error!("Error getting route: {:?}", err.message());
@@ -460,6 +445,16 @@ fn amount_or_all(msat: u64) -> Option<pb::AmountOrAll> {
         value: Some(pb::amount_or_all::Value::Amount(amount(msat))),
     })
 }
+// keysend's maxfeepercent (default 0.5) and exemptfee (default 5000 msat) as
+// xkeysend's single maxfee; None keeps xkeysend's own default
+fn keysend_maxfee(amt_msat: u64, maxfeepercent: Option<f64>, exemptfee: Option<u64>) -> Option<u64> {
+    if maxfeepercent.is_none() && exemptfee.is_none() {
+        return None;
+    }
+    let percent_fee = (amt_msat as f64 * maxfeepercent.unwrap_or(0.5) / 100.0) as u64;
+    Some(std::cmp::max(exemptfee.unwrap_or(5_000), percent_fee))
+}
+
 fn amount(msat: u64) -> pb::Amount {
     pb::Amount { msat }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1004,7 +1004,11 @@ pub async fn handle(
                 }
                 ClnCmd::PayInvoice(i) => {
                     let paid = client.pay(&i.payment_request).await?;
-                    Some(serde_json::to_string(&paid)?)
+                    // xpay has no status: it only returns once paid, and failures
+                    // are errors. The admin UI checks for pay's status 0 (COMPLETE).
+                    let mut res = serde_json::to_value(&paid)?;
+                    res["status"] = serde_json::json!(0);
+                    Some(serde_json::to_string(&res)?)
                 }
                 ClnCmd::PayKeysend(i) => {
                     let paid = client.keysend(&i.dest, i.amt as u64, i.route_hint, i.maxfeepercent, i.exemptfee, None).await?;
@@ -1014,8 +1018,11 @@ pub async fn handle(
                     let closed = client.close(&i.id, &i.destination).await?;
                     let mut hm = HashMap::new();
                     hm.insert("type", closed.item_type.to_string());
-                    hm.insert("txid", hex::encode(closed.txid()));
-                    hm.insert("tx", hex::encode(closed.tx()));
+                    // tx/txid were the final close tx, now the last of txs/txids
+                    let txid = closed.txids.last().map(hex::encode).unwrap_or_default();
+                    let tx = closed.txs.last().map(hex::encode).unwrap_or_default();
+                    hm.insert("txid", txid);
+                    hm.insert("tx", tx);
                     Some(serde_json::to_string(&hm)?)
                 }
                 ClnCmd::ListInvoices(i) => match i {

--- a/src/images/cln.rs
+++ b/src/images/cln.rs
@@ -320,17 +320,28 @@ fn cln(img: &ClnImage, btc: ClnBtcArgs, lss: Option<lss::LssImage>) -> Config<St
     if img.offline.unwrap_or(false) {
         cmd.push("--offline".to_string());
     }
+    // CLN_ALLOW_DEPRECATED_APIS=false turns off pay, getroute and keysend
+    // (removed in CLN v27.03) so anything still calling them fails loudly.
+    // Only applied when the container is created.
+    let deprecated_apis_off = getenv("CLN_ALLOW_DEPRECATED_APIS")
+        .map(|v| v == "false")
+        .unwrap_or(false);
     if let Some(hsms) = &img.seed {
         // CLN 26.06+ only accepts dev-force-* options under --developer, and
-        // --developer disables deprecated RPCs (pay, getroute) that the mixer
-        // still uses, so re-enable them explicitly.
+        // --developer disables deprecated RPCs (pay, getroute, keysend) that the
+        // mixer and swarm still use, so re-enable them unless told not to.
         if !cmd.iter().any(|c| c == "--developer") {
             cmd.push("--developer".to_string());
         }
-        cmd.push("--allow-deprecated-apis=true".to_string());
+        if !deprecated_apis_off {
+            cmd.push("--allow-deprecated-apis=true".to_string());
+        }
         cmd.push(format!("--dev-force-bip32-seed={}", hsms));
         let privkey = privkey_from_seed(&hsms).expect("bad seed");
         cmd.push(format!("--dev-force-privkey={}", privkey));
+    }
+    if deprecated_apis_off {
+        cmd.push("--allow-deprecated-apis=false".to_string());
     }
     if let Some(u) = &btc.user {
         if let Some(p) = &btc.pass {

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -80,6 +80,29 @@ pub async fn mine_blocks(clients: &mut Clients, btc_name: &str, n: u64) -> Resul
     Ok(())
 }
 
+// wait until node1 sees a 2-hop route to node3 (gossip from both channels arrived)
+pub async fn try_check_2_hops(clients: &mut Clients, node1: &str, node3: &str) {
+    for i in 0..200 {
+        let res = check_2_hops(clients, node1, node3).await;
+        if res.is_ok() {
+            return;
+        }
+        log::info!("retrying get_routes to {}: {}...", node3, i);
+        sleep(2000).await;
+    }
+}
+
+async fn check_2_hops(clients: &mut Clients, node1: &str, node3: &str) -> Result<()> {
+    let cln3_pubkey = get_pubkey_cln(clients, node3).await?;
+    let cln1 = clients.cln.get_mut(node1).unwrap();
+    let res = cln1.get_routes(&cln3_pubkey, 1000).await?;
+    let hops = res.routes.first().map(|r| r.path.len()).unwrap_or(0);
+    if hops < 2 {
+        return Err(anyhow::anyhow!("no route found"));
+    }
+    Ok(())
+}
+
 pub async fn new_chan_from_cln1(
     clients: &mut Clients,
     sender_name: &str,
@@ -97,7 +120,14 @@ pub async fn new_chan_from_cln1(
         .iter()
         .filter(|peer| hex::encode(peer.id.clone()) == peer_pubkey)
     {
-        if p.num_channels.unwrap_or(0) > 0 {
+        if p.num_channels > 0 {
+            // recreated containers get new IPs but CLN only remembers the old
+            // address (and none at all for inbound peers), so reconnect by hostname
+            if !p.connected {
+                log::info!("reconnecting to {}", peer_name);
+                cln1.connect_peer(peer_pubkey, &domain(peer_name), peer_port)
+                    .await?;
+            }
             log::info!("skipping new channel setup");
             return Ok(());
         }
@@ -160,7 +190,7 @@ pub async fn cln_keysend_to(
     {
         Ok(sent_keysend) => println!(
             "[CLN] => sent_keysend to {} {:?}",
-            recip_pubkey, sent_keysend.status
+            recip_pubkey, sent_keysend.amount_sent_msat
         ),
         Err(e) => {
             println!("[CLN] keysend err {:?}", e)


### PR DESCRIPTION
## Summary

Moves the swarm's CLN client off the RPCs deprecated in CLN v26.06 and removed in v27.03, and extends the local regtest harness used to test that. Plan and background: `docs/cln-upgrade.md` section 6 in stakwork/sphinx. Companion mixer PR: https://github.com/stakwork/sphinx/pull/348

**CLN client**
- Bump `cln-grpc` 0.3.0 -> 0.7.0 and `tonic` 0.11 -> 0.14.
- `PayInvoice` (admin UI) uses `xpay`. `xpay` has no `status`, so the handler adds `status: 0`, which is what the UI checks; `xpay` only returns once paid. It uses xpay's default fee cap (1%, at least 5000 msat).
- `PayKeysend` and the harness setup keysends use `xkeysend`. `maxfeepercent`/`exemptfee` become one `maxfee`, with keysend's old defaults (0.5%, 5000 msat) filling in whichever is missing. TLVs are sent as `{"<type>": "<hex>"}`. A `route_hint` now returns an error: xkeysend has no routehints, and the UI only sends one if `window.route_hint` is set in the browser console.
- The harness's two-hop route check uses `getroutes`.
- 0.7.0 type fixes: `CloseChannel` reports the last of `txs`/`txids` under the same `tx`/`txid` keys; `num_channels` is no longer optional.

**Harness**
- `cargo run --bin cln` now starts three CLN nodes (cln_1 -> cln_2 <- cln_3) with the v1 seeds and dev mode, and waits for the two-hop route. `try_check_2_hops` moved from `src/bin/v1` into `setup`.
- Setup reconnects a disconnected peer when the channel already exists. Recreated containers get new IPs and CLN only remembers the old address, which used to leave the route check stuck.
- New env var `CLN_ALLOW_DEPRECATED_APIS=false` starts CLN with `--allow-deprecated-apis=false`. The default is unchanged (`true` whenever a seed is set).

## Deploy note

This needs CLN v26.06 or newer, i.e. `cln-sphinx` v0.4.0: the `getroutes` hop fields were added in v26.06 and `maxparts` needs v25.09. The `--allow-deprecated-apis=true` default can be removed once a staging swarm passes with `CLN_ALLOW_DEPRECATED_APIS=false`.

## Testing

All on regtest with CLN v26.06.7 and `CLN_ALLOW_DEPRECATED_APIS=false`; CLN answers `getroute` and `keysend` with "Command is deprecated".
- `--bin cln`: setup (reconnects, six `xkeysend`s including the TLV one, `getroutes` route check) passes. A TLV value sent with `xkeysend` arrives intact in the receiver's `keysend: ...` invoice description.
- Admin API on cln_1: `PayInvoice` pays a cln_3 invoice (preimage matches, UI gets `status: 0`); `PayKeysend` works plain and with `maxfeepercent`/`exemptfee`; `route_hint` returns the new error; `GetInfo`, `ListPeers`, `ListPeerChannels`, `ListFunds`, `ListInvoices` and `ListPays` return the fields `app/src/helpers/cln.ts` reads.
- `yarn swarm` (stakwork/sphinx `wasm/test`) on `--bin sphinx`, with a mixer image built from the companion PR: every step passed; cln_2 settled 13 forwards with none failed.
